### PR TITLE
Implement in-memory version service

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
@@ -1,16 +1,117 @@
 package com.gu.tableversions.core
 
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import com.gu.tableversions.core.InMemoryTableVersions.TableUpdates
+import com.gu.tableversions.core.TableVersions.CommitResult.SuccessfulCommit
+import com.gu.tableversions.core.TableVersions.{AddPartitionVersion, PartitionOperation, RemovePartition, TableUpdate}
+
 /**
   * Reference implementation of the table version store. Does not persist state.
   */
-class InMemoryTableVersions[F[_]] extends TableVersions[F] {
+class InMemoryTableVersions[F[_]] private (allUpdates: Ref[F, TableUpdates])(implicit F: Sync[F])
+    extends TableVersions[F] {
 
-  override def init(table: TableName): F[Unit] = ???
+  override def init(table: TableName): F[Unit] =
+    allUpdates.update { prev =>
+      if (prev.contains(table)) prev else prev + (table -> Nil)
+    }
 
-  override def currentVersion(table: TableName): F[TableVersion] = ???
+  override def currentVersion(table: TableName): F[TableVersion] =
+    // Derive current version of a table by folding over the history of changes
+    for {
+      allTableUpdates <- allUpdates.get
+      tableUpdates <- allTableUpdates
+        .get(table)
+        .fold(F.raiseError[List[TableUpdate]](new Exception(s"Table '$table' not found")))(F.pure)
+      operations = tableUpdates.flatMap(_.partitionUpdates)
+    } yield InMemoryTableVersions.applyUpdate(TableVersion.empty)(operations)
 
-  override def nextVersions(table: TableName, partitionColumns: List[Partition]): F[List[PartitionVersion]] = ???
+  override def nextVersions(table: TableName, partitions: List[Partition]): F[List[PartitionVersion]] = {
+    def incrementVersion(partitionVersion: PartitionVersion): PartitionVersion =
+      partitionVersion.copy(version = VersionNumber(partitionVersion.version.number + 1))
 
-  override def commit(newVersion: TableVersions.TableUpdate): F[TableVersions.CommitResult] = ???
+    for {
+      tableVersion <- currentVersion(table)
+      nextVersions = partitions.map(
+        partition =>
+          tableVersion.partitionVersions
+            .find(_.partition == partition)
+            .map(incrementVersion)
+            .getOrElse(PartitionVersion(partition, VersionNumber(1))))
+    } yield nextVersions
+  }
+
+  override def commit(table: TableName, update: TableVersions.TableUpdate): F[TableVersions.CommitResult] = {
+    // Check if the committed partitions match the "next versions" for this
+    // If not, error
+    // Otherwise add the update to the list
+
+    val applyUpdate: TableUpdates => Either[Exception, TableUpdates] = { currentTableUpdates =>
+      // First, just apply the updates to the list in all cases
+      // Then do the bit where I actually check that the committed versions match the current 'next' versions
+
+      def updatesMatchCurrentVersions: Boolean = { true } // TODO!
+
+      if (currentTableUpdates.contains(table) && updatesMatchCurrentVersions) {
+        val updated = currentTableUpdates + (table -> (currentTableUpdates(table) :+ update))
+        Right(updated)
+      } else
+        Left(new Exception(s"Unknown table '${table.fullyQualifiedName}'"))
+    }
+
+    // TODO: response
+    InMemoryTableVersions.modifyEither(allUpdates)(applyUpdate).map(_ => SuccessfulCommit)
+  }
+
+}
+
+object InMemoryTableVersions {
+
+  // TODO: Put somewhere else, as syntax on `Ref`
+  def modifyEither[F[_]: Sync, A, E <: Throwable](ref: Ref[F, A])(f: A => Either[E, A]): F[Unit] =
+    ref
+      .modify(a =>
+        f(a) match {
+          case Left(e)     => (a, e.raiseError[F, Unit])
+          case Right(newA) => (newA, ().pure[F])
+      })
+      .flatten
+
+  type TableUpdates = Map[TableName, List[TableUpdate]]
+
+  /**
+    * Safe constructor
+    */
+  def apply[F[_]](implicit F: Sync[F]): F[InMemoryTableVersions[F]] =
+    for {
+      ref <- Ref[F].of(Map[TableName, List[TableUpdate]]())
+      service = new InMemoryTableVersions[F](ref)
+    } yield service
+
+  /**
+    * Produce current table version based on history of updates.
+    */
+  private[core] def applyUpdate(initial: TableVersion)(operations: List[PartitionOperation]): TableVersion = {
+
+    def applyOp(agg: Map[Partition, VersionNumber], op: PartitionOperation): Map[Partition, VersionNumber] = op match {
+      case AddPartitionVersion(partitionVersion: PartitionVersion) =>
+        agg + (partitionVersion.partition -> partitionVersion.version)
+      case RemovePartition(partition: Partition) =>
+        agg - partition
+    }
+
+    val initialVersions: Map[Partition, VersionNumber] =
+      initial.partitionVersions.map(pv => pv.partition -> pv.version).toMap
+
+    val latestVersions = operations.foldLeft(initialVersions)(applyOp)
+
+    val latestPartitionVersions = latestVersions.toList.map {
+      case (partition, version) => PartitionVersion(partition, version)
+    }
+
+    TableVersion(latestPartitionVersions)
+  }
 
 }

--- a/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
@@ -30,17 +30,31 @@ class InMemoryTableVersions[F[_]] private (allUpdates: Ref[F, TableUpdates])(imp
     } yield InMemoryTableVersions.applyUpdate(TableVersion.empty)(operations)
 
   override def nextVersions(table: TableName, partitions: List[Partition]): F[List[PartitionVersion]] = {
-    def incrementVersion(partitionVersion: PartitionVersion): PartitionVersion =
-      partitionVersion.copy(version = VersionNumber(partitionVersion.version.number + 1))
+    def maxVersions(operations: List[PartitionVersion]): Map[Partition, VersionNumber] =
+      operations.foldLeft(Map.empty[Partition, VersionNumber]) { (agg, partitionVersion) =>
+        val previousVersion =
+          agg.getOrElse(partitionVersion.partition, VersionNumber(0))
+        val maxVersion =
+          if (previousVersion.number > partitionVersion.version.number) previousVersion else partitionVersion.version
+
+        agg + (partitionVersion.partition -> maxVersion)
+      }
+
+    def nextVersion(previousVersion: Option[VersionNumber]): VersionNumber =
+      previousVersion
+        .map(v => VersionNumber(v.number + 1))
+        .getOrElse(VersionNumber(1))
 
     for {
-      tableVersion <- currentVersion(table)
-      nextVersions = partitions.map(
-        partition =>
-          tableVersion.partitionVersions
-            .find(_.partition == partition)
-            .map(incrementVersion)
-            .getOrElse(PartitionVersion(partition, VersionNumber(1))))
+      allTableUpdates <- allUpdates.get
+      tableUpdates <- allTableUpdates
+        .get(table)
+        .fold(F.raiseError[List[TableUpdate]](new Exception(s"Table '$table' not found")))(F.pure)
+      addedPartitions = tableUpdates.flatMap(_.partitionUpdates).collect {
+        case AddPartitionVersion(partitionVersion) => partitionVersion
+      }
+      maxUsedVersions = maxVersions(addedPartitions)
+      nextVersions = partitions.map(p => PartitionVersion(p, nextVersion(maxUsedVersions.get(p))))
     } yield nextVersions
   }
 

--- a/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
@@ -55,7 +55,10 @@ object TableVersions {
 
   /** ADT for operations on individual partitions. */
   sealed trait PartitionOperation
-  final case class AddPartitionVersion(version: PartitionVersion) extends PartitionOperation
-  final case class RemovePartition(partition: Partition) extends PartitionOperation
+
+  object PartitionOperation {
+    final case class AddPartitionVersion(version: PartitionVersion) extends PartitionOperation
+    final case class RemovePartition(partition: Partition) extends PartitionOperation
+  }
 
 }

--- a/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
@@ -26,7 +26,7 @@ trait TableVersions[F[_]] {
     * This performs no checking if data has been written to the associated paths but it will verify that these versions
     * 1) haven't been committed before and 2) these are the next versions to be committed for each of the partitions.
     */
-  def commit(newVersion: TableVersions.TableUpdate): F[CommitResult]
+  def commit(table: TableName, update: TableVersions.TableUpdate): F[CommitResult]
 
 }
 
@@ -37,7 +37,7 @@ object TableVersions {
       userId: UserId,
       message: UpdateMessage,
       timestamp: Instant,
-      updatedPartitions: List[PartitionVersion])
+      partitionUpdates: List[PartitionOperation])
 
   final case class UpdateMessage(content: String) extends AnyVal
 
@@ -52,5 +52,10 @@ object TableVersions {
   }
 
   case class ErrorMessage(value: String) extends AnyVal
+
+  /** ADT for operations on individual partitions. */
+  sealed trait PartitionOperation
+  final case class AddPartitionVersion(version: PartitionVersion) extends PartitionOperation
+  final case class RemovePartition(partition: Partition) extends PartitionOperation
 
 }

--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -57,6 +57,12 @@ final case class VersionNumber(number: Int) extends AnyVal
 
 final case class PartitionVersion(partition: Partition, version: VersionNumber)
 
+object PartitionVersion {
+
+  def snapshot(version: VersionNumber): PartitionVersion = PartitionVersion(Partition.snapshotPartition, version)
+
+}
+
 //
 // Tables
 //
@@ -71,3 +77,11 @@ final case class TableDefinition(name: TableName, location: URI, partitionSchema
   * The complete set of version information for all partitions in a table.
   */
 final case class TableVersion(partitionVersions: List[PartitionVersion])
+
+object TableVersion {
+
+  def snapshotVersion(version: VersionNumber): TableVersion = TableVersion(List(PartitionVersion.snapshot(version)))
+
+  val empty = TableVersion(Nil)
+
+}

--- a/core/src/main/scala/com/gu/tableversions/core/util/RichRef.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/util/RichRef.scala
@@ -19,7 +19,7 @@ object RichRef {
         .modify(a =>
           f(a) match {
             case Left(e)     => (a, e.raiseError[F, Unit])
-            case Right(newA) => (newA, ().pure[F])
+            case Right(newA) => (newA, F.unit)
         })
         .flatten
   }

--- a/core/src/main/scala/com/gu/tableversions/core/util/RichRef.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/util/RichRef.scala
@@ -1,0 +1,27 @@
+package com.gu.tableversions.core.util
+
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.implicits._
+
+object RichRef {
+
+  implicit class RichRef[F[_], A](underlying: Ref[F, A])(implicit F: Sync[F]) {
+
+    /**
+      * Perform a conditional update on the `Ref` that produces a failure for an invalid update.
+      *
+      * If the provided update function `f` returns a `Right[A]`, the contained value will be used to update the `Ref`.
+      * If `f` returns a `Left[E]`, this will cause the return `F` to be an error.
+      */
+    def modifyEither[E <: Throwable](f: A => Either[E, A]): F[Unit] =
+      underlying
+        .modify(a =>
+          f(a) match {
+            case Left(e)     => (a, e.raiseError[F, Unit])
+            case Right(newA) => (newA, ().pure[F])
+        })
+        .flatten
+  }
+
+}

--- a/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
@@ -2,7 +2,7 @@ package com.gu.tableversions.core
 
 import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core.TableVersions.{AddPartitionVersion, RemovePartition}
+import com.gu.tableversions.core.TableVersions.PartitionOperation._
 import org.scalatest.{FlatSpec, Matchers}
 
 class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersionsSpec {

--- a/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
@@ -1,0 +1,78 @@
+package com.gu.tableversions.core
+
+import cats.effect.IO
+import com.gu.tableversions.core.Partition.PartitionColumn
+import com.gu.tableversions.core.TableVersions.{AddPartitionVersion, RemovePartition}
+import org.scalatest.{FlatSpec, Matchers}
+
+class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersionsSpec {
+
+  val date = PartitionColumn("date")
+
+  "The reference implementation for the TableVersions service" should behave like tableVersionsBehaviour {
+    InMemoryTableVersions[IO]
+  }
+
+  "Combining partition operations" should "produce an empty table version when no updates have been applied" in {
+    InMemoryTableVersions.applyUpdate(TableVersion.empty)(Nil) shouldBe TableVersion.empty
+  }
+
+  it should "produce the same table when an empty update is applied" in {
+    val partitionVersions = List(
+      PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(1))
+    )
+    val tableVersion = TableVersion(partitionVersions)
+    InMemoryTableVersions.applyUpdate(tableVersion)(Nil) shouldBe tableVersion
+  }
+
+  it should "produce a version with the given partitions when no previous partition versions exist" in {
+    val partitionVersions = List(
+      PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(1))
+    )
+    val partitionUpdates = partitionVersions.map(AddPartitionVersion)
+    InMemoryTableVersions.applyUpdate(TableVersion.empty)(partitionUpdates) shouldBe TableVersion(partitionVersions)
+  }
+
+  it should "pick the latest version when an existing partition version is updated" in {
+
+    val initialPartitionVersions = List(
+      PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(2)),
+      PartitionVersion(Partition(date, "2019-03-03"), VersionNumber(1))
+    )
+    val initialTableVersion = TableVersion(initialPartitionVersions)
+
+    val partitionUpdates = List(AddPartitionVersion(PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(3))))
+
+    val expectedPartitionVersions = List(
+      PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-03"), VersionNumber(1))
+    )
+
+    InMemoryTableVersions.applyUpdate(initialTableVersion)(partitionUpdates) shouldBe TableVersion(
+      expectedPartitionVersions)
+  }
+
+  it should "remove an existing partition" in {
+    val initialPartitionVersions = List(
+      PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(2)),
+      PartitionVersion(Partition(date, "2019-03-03"), VersionNumber(1))
+    )
+    val initialTableVersion = TableVersion(initialPartitionVersions)
+
+    val partitionUpdates = List(RemovePartition(Partition(date, "2019-03-02")))
+
+    val expectedPartitionVersions = List(
+      PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
+      PartitionVersion(Partition(date, "2019-03-03"), VersionNumber(1))
+    )
+
+    InMemoryTableVersions.applyUpdate(initialTableVersion)(partitionUpdates) shouldBe TableVersion(
+      expectedPartitionVersions)
+  }
+
+}

--- a/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions.CommitResult.SuccessfulCommit
+import com.gu.tableversions.core.TableVersions.PartitionOperation.{AddPartitionVersion, RemovePartition}
 import com.gu.tableversions.core.TableVersions._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -27,16 +28,21 @@ trait TableVersionsSpec {
       val scenario = for {
         tableVersions <- emptyTableVersions
         _ <- tableVersions.init(table)
+        tableVersion1 <- tableVersions.currentVersion(table)
+
         _ <- tableVersions.init(table)
+        tableVersion2 <- tableVersions.currentVersion(table)
+
         _ <- tableVersions.init(table)
+        tableVersion3 <- tableVersions.currentVersion(table)
 
-        tableVersion <- tableVersions.currentVersion(table)
+      } yield (tableVersion1, tableVersion2, tableVersion3)
 
-      } yield tableVersion
+      val (tableVersion1, tableVersion2, tableVersion3) = scenario.unsafeRunSync()
 
-      val tableVersion = scenario.unsafeRunSync()
-
-      tableVersion shouldBe TableVersion.empty
+      tableVersion1 shouldBe TableVersion.empty
+      tableVersion2 shouldBe tableVersion1
+      tableVersion3 shouldBe tableVersion1
     }
 
     it should "allow partition versions of a partitioned table to be updated and queried" in {

--- a/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
@@ -187,8 +187,6 @@ trait TableVersionsSpec {
       ex.getMessage should include regex "Unknown table.*schema.*table"
     }
 
-    // TODO: invalid commit/mismatched versions (for now anyway)
-
   }
 
   private def timestamp(tick: Long): Instant = Instant.ofEpochSecond(1553705295L + (tick * 60))

--- a/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
@@ -1,0 +1,196 @@
+package com.gu.tableversions.core
+
+import java.time.Instant
+
+import cats.effect.IO
+import com.gu.tableversions.core.Partition.PartitionColumn
+import com.gu.tableversions.core.TableVersions.CommitResult.SuccessfulCommit
+import com.gu.tableversions.core.TableVersions._
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Spec containing tests that apply across all TableVersions implementations.
+  *
+  * These are black box tests purely in terms of the TableVersions interface.
+  */
+trait TableVersionsSpec {
+  this: FlatSpec with Matchers =>
+
+  def tableVersionsBehaviour(emptyTableVersions: IO[TableVersions[IO]]): Unit = {
+
+    val table = TableName("schema", "table")
+    val userId = UserId("Test user")
+    val date = PartitionColumn("date")
+
+    it should "have an idempotent 'init' operation" in {
+
+      val scenario = for {
+        tableVersions <- emptyTableVersions
+        _ <- tableVersions.init(table)
+        _ <- tableVersions.init(table)
+        _ <- tableVersions.init(table)
+
+        tableVersion <- tableVersions.currentVersion(table)
+
+      } yield tableVersion
+
+      val tableVersion = scenario.unsafeRunSync()
+
+      tableVersion shouldBe TableVersion.empty
+    }
+
+    it should "allow partition versions of a partitioned table to be updated and queried" in {
+
+      val initialPartitionVersions = List(
+        PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(1)),
+        PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(1))
+      )
+
+      val partitionUpdate1 = List(
+        PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(2)),
+        PartitionVersion(Partition(date, "2019-03-03"), VersionNumber(1))
+      )
+
+      val scenario = for {
+        tableVersions <- emptyTableVersions
+        _ <- tableVersions.init(table)
+
+        initialTableVersion <- tableVersions.currentVersion(table)
+
+        // Add some partitions
+        commitResult1 <- tableVersions.commit(
+          table,
+          TableUpdate(userId,
+                      UpdateMessage("Add initial partitions"),
+                      timestamp(1),
+                      initialPartitionVersions.map(AddPartitionVersion))
+        )
+
+        version1 <- tableVersions.currentVersion(table)
+
+        // Do an update with one updated partition and one new one
+        nextVersions1 <- tableVersions.nextVersions(table, partitionUpdate1.map(_.partition))
+        commitResult2 <- tableVersions.commit(
+          table,
+          TableUpdate(userId, UpdateMessage("First update"), timestamp(2), partitionUpdate1.map(AddPartitionVersion)))
+        version2 <- tableVersions.currentVersion(table)
+
+      } yield (initialTableVersion, commitResult1, version1, nextVersions1, commitResult2, version2)
+
+      val (initialTableVersion, commitResult1, version1, nextVersions1, commitResult2, version2) =
+        scenario.unsafeRunSync()
+
+      initialTableVersion shouldBe TableVersion.empty
+      commitResult1 shouldBe SuccessfulCommit
+      version1 shouldBe TableVersion(initialPartitionVersions)
+
+      nextVersions1 shouldBe partitionUpdate1
+      commitResult2 shouldBe SuccessfulCommit
+      version2.partitionVersions should contain theSameElementsAs List(
+        PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(1)),
+        PartitionVersion(Partition(date, "2019-03-02"), VersionNumber(2)),
+        PartitionVersion(Partition(date, "2019-03-03"), VersionNumber(1))
+      )
+
+      // TODO: Remove a partition
+    }
+
+    it should "allow versions of a snapshot table to be updated and queried" in {
+
+      val version1 = TableVersion.snapshotVersion(VersionNumber(1))
+      val version2 = TableVersion.snapshotVersion(VersionNumber(2))
+
+      val scenario = for {
+        tableVersions <- emptyTableVersions
+        _ <- tableVersions.init(table)
+        initialTableVersion <- tableVersions.currentVersion(table)
+
+        nextVersion1 <- tableVersions.nextVersions(table, List(Partition.snapshotPartition))
+        commitResult1 <- tableVersions.commit(table,
+                                              TableUpdate(userId,
+                                                          UpdateMessage("First commit"),
+                                                          timestamp(1),
+                                                          version1.partitionVersions.map(AddPartitionVersion)))
+        currentVersion1 <- tableVersions.currentVersion(table)
+
+        nextVersion2 <- tableVersions.nextVersions(table, List(Partition.snapshotPartition))
+        commitResult2 <- tableVersions.commit(table,
+                                              TableUpdate(userId,
+                                                          UpdateMessage("Second commit"),
+                                                          timestamp(2),
+                                                          version1.partitionVersions.map(AddPartitionVersion)))
+        currentVersion2 <- tableVersions.currentVersion(table)
+
+      } yield
+        (initialTableVersion,
+         nextVersion1,
+         commitResult1,
+         currentVersion1,
+         nextVersion2,
+         commitResult2,
+         currentVersion2)
+
+      val (initialTableVersion,
+           nextVersion1,
+           commitResult1,
+           currentVersion1,
+           nextVersion2,
+           commitResult2,
+           currentVersion2) =
+        scenario.unsafeRunSync()
+
+      initialTableVersion shouldBe TableVersion.empty
+      nextVersion1 shouldBe version1.partitionVersions
+
+      commitResult1 shouldBe SuccessfulCommit
+      currentVersion1 shouldBe version1
+
+      nextVersion2 shouldBe version2.partitionVersions
+      commitResult2 shouldBe SuccessfulCommit
+      currentVersion2 shouldBe currentVersion2
+    }
+
+    it should "return an error if trying to get current version of an unknown table" in {
+      val scenario = for {
+        tableVersions <- emptyTableVersions
+        version <- tableVersions.currentVersion(table)
+      } yield version
+
+      val ex = the[Exception] thrownBy scenario.unsafeRunSync()
+      ex.getMessage should include regex "schema.*table.*not found"
+    }
+
+    it should "return an error if trying to get next versions from an unknown table" in {
+      val scenario = for {
+        tableVersions <- emptyTableVersions
+        version <- tableVersions.nextVersions(TableName("schema", "table"), List(Partition.snapshotPartition))
+      } yield version
+
+      val ex = the[Exception] thrownBy scenario.unsafeRunSync()
+      ex.getMessage should include regex "schema.*table.*not found"
+    }
+
+    it should "return an error if trying to commit changes for an unknown table" in {
+      val scenario = for {
+        tableVersions <- emptyTableVersions
+
+        version <- tableVersions.commit(
+          TableName("schema", "table"),
+          TableUpdate(userId,
+                      UpdateMessage("Commit initial partitions"),
+                      timestamp(1),
+                      List(AddPartitionVersion(PartitionVersion.snapshot(VersionNumber(1)))))
+        )
+      } yield version
+
+      val ex = the[Exception] thrownBy scenario.unsafeRunSync()
+      ex.getMessage should include regex "Unknown table.*schema.*table"
+    }
+
+    // TODO: invalid commit/mismatched versions (for now anyway)
+
+  }
+
+  private def timestamp(tick: Long): Instant = Instant.ofEpochSecond(1553705295L + (tick * 60))
+
+}

--- a/core/src/test/scala/com/gu/tableversions/core/util/RichRefSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/util/RichRefSpec.scala
@@ -1,0 +1,36 @@
+package com.gu.tableversions.core.util
+
+import cats.effect.IO
+import cats.effect.concurrent.Ref
+import org.scalatest.{FlatSpec, Matchers}
+
+class RichRefSpec extends FlatSpec with Matchers {
+
+  import RichRef._
+
+  // A test update function
+  val doubleIfEven: Int => Either[Exception, Int] = n =>
+    if (n % 2 == 0) Right(n * 2) else Left(new Exception(s"Won't double an odd number: $n"))
+
+  "Applying a valid update" should "update the Ref and return success" in {
+    val test = for {
+      ref <- Ref.of[IO, Int](42)
+      _ <- ref.modifyEither(doubleIfEven)
+      finalValue <- ref.get
+    } yield finalValue
+
+    val result = test.unsafeRunSync()
+    result shouldBe 42 * 2
+  }
+
+  "Applying an update that isn't valid" should "return the failure" in {
+    val test = for {
+      ref <- Ref.of[IO, Int](3)
+      _ <- ref.modifyEither(doubleIfEven)
+    } yield ()
+
+    val ex = the[Exception] thrownBy test.unsafeRunSync()
+    ex.getMessage should include("Won't double an odd number: 3")
+  }
+
+}

--- a/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
@@ -24,7 +24,7 @@ class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHi
   "Writing multiple versions of a date partitioned dataset" should "produce distinct partition versions" ignore {
 
     import spark.implicits._
-    implicit val tableVersions = new InMemoryTableVersions[IO]()
+    implicit val tableVersions = InMemoryTableVersions[IO].unsafeRunSync()
     implicit val metastore = new SparkHiveMetastore[IO]()
 
     val loader =

--- a/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
@@ -9,6 +9,7 @@ import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions.UserId
 import com.gu.tableversions.core._
 import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite}
+import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, RemoteIterator}
 import org.scalatest.{FlatSpec, Matchers}
 
 class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite {
@@ -21,7 +22,7 @@ class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHi
     PartitionSchema(List(PartitionColumn("date")))
   )
 
-  "Writing multiple versions of a date partitioned dataset" should "produce distinct partition versions" ignore {
+  "Writing multiple versions of a date partitioned dataset" should "produce distinct partition versions" in {
 
     import spark.implicits._
     implicit val tableVersions = InMemoryTableVersions[IO].unsafeRunSync()
@@ -100,14 +101,17 @@ class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHi
     //    instead of querying storage directly)
     //   Also: query version history for table
 
+    // Check that we still have the previous version of the updated partition
     spark.read
-      .parquet(tableUri.toString + "2019-03-14/v1")
+      .parquet(tableUri.toString + "/date=2019-03-14/v1")
       .as[Pageview]
       .collect() should contain theSameElementsAs pageviewsDay2
   }
 
   def versionDirs(tableLocation: URI, partition: String): List[String] = {
-    val dir = Paths.get(s"$tableLocation/$partition")
+    assert(tableLocation.toString.startsWith("file://"))
+    val basePath = tableLocation.toString.drop("file://".length)
+    val dir = Paths.get(s"$basePath/$partition")
     val dirList = Option(dir.toFile.list()).map(_.toList).getOrElse(Nil)
     dirList.filter(_.matches("v\\d+"))
   }

--- a/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
@@ -9,7 +9,6 @@ import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions.UserId
 import com.gu.tableversions.core._
 import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite}
-import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, RemoteIterator}
 import org.scalatest.{FlatSpec, Matchers}
 
 class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite {

--- a/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
@@ -62,16 +62,12 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
   def partitionVersions(tableLocation: Path): Map[(String, String), List[String]] = {
 
     def datePartitions(dir: Path): List[String] = {
-      println(s"Looking for date partitions in '$dir'")
       val datePartitionPattern = "date=\\d\\d\\d\\d-\\d\\d-\\d\\d"
       dir.toFile.list().toList.filter(_.matches(datePartitionPattern))
     }
 
-    def versions(dir: Path): List[String] = {
-      println(s"Looking for versions in '$dir'")
-      println(s"dir.toFile.list() = ${dir.toFile.list().toList}")
+    def versions(dir: Path): List[String] =
       dir.toFile.list().toList.filter(_.matches("v\\d+"))
-    }
 
     val impressionDatePartitions: List[String] = datePartitions(tableLocation)
 

--- a/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
@@ -18,7 +18,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
   "Writing multiple versions of a snapshot dataset" should "produce distinct versions" ignore {
     import spark.implicits._
 
-    implicit val tableVersions = new InMemoryTableVersions[IO]()
+    implicit val tableVersions = InMemoryTableVersions[IO].unsafeRunSync()
     implicit val metastore = new SparkHiveMetastore[IO]()
 
     val userId = UserId("test user")

--- a/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
@@ -15,7 +15,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
 
   val table = TableDefinition(TableName(schema, "users"), tableUri, PartitionSchema.snapshot)
 
-  "Writing multiple versions of a snapshot dataset" should "produce distinct versions" ignore {
+  "Writing multiple versions of a snapshot dataset" should "produce distinct versions" in {
     import spark.implicits._
 
     implicit val tableVersions = InMemoryTableVersions[IO].unsafeRunSync()
@@ -62,7 +62,9 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
   }
 
   def versionDirs(tableLocation: URI): List[String] = {
-    val dir = Paths.get(tableLocation)
+    assert(tableLocation.toString.startsWith("file://"))
+    val basePath = tableLocation.toString.drop("file://".length)
+    val dir = Paths.get(basePath)
     dir.toFile.list().toList.filter(_.matches("v\\d+"))
   }
 

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreObjectSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreObjectSpec.scala
@@ -10,7 +10,7 @@ class MetastoreObjectSpec extends FlatSpec with Matchers {
   val date = PartitionColumn("date")
 
   "Computing differences" should "produce operations to add new partitions" in {
-    val oldVersion = TableVersion(Nil)
+    val oldVersion = TableVersion.empty
 
     val newPartitionVersions = List(
       PartitionVersion(Partition(date, "2019-03-01"), VersionNumber(3)),
@@ -33,7 +33,7 @@ class MetastoreObjectSpec extends FlatSpec with Matchers {
     )
     val oldVersion = TableVersion(oldPartitionVersions)
 
-    val newVersion = TableVersion(Nil)
+    val newVersion = TableVersion.empty
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreSpec.scala
@@ -109,7 +109,7 @@ trait MetastoreSpec {
       val (initialVersion, versionAfterFirstUpdate, versionAfterSecondUpdate, versionAfterPartitionRemoved) =
         scenario.unsafeRunSync()
 
-      initialVersion shouldBe TableVersion(Nil)
+      initialVersion shouldBe TableVersion.empty
 
       versionAfterFirstUpdate shouldBe
         TableVersion(

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -64,8 +64,9 @@ object VersionedDataset {
       // Get latest version details and Metastore table details and sync the Metastore to match,
       // effectively switching the table to the new version.
       latestTableVersion <- tableVersions.currentVersion(table.name)
+
       metastoreVersion <- metastore.currentVersion(table.name)
-      metastoreUpdate = metastore.computeChanges(latestTableVersion, metastoreVersion)
+      metastoreUpdate = metastore.computeChanges(metastoreVersion, latestTableVersion)
 
       // Sync Metastore to match
       _ <- metastore.update(table.name, metastoreUpdate)

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.time.Instant
 
 import cats.effect.IO
-import com.gu.tableversions.core.TableVersions.{TableUpdate, UpdateMessage, UserId}
+import com.gu.tableversions.core.TableVersions.{AddPartitionVersion, TableUpdate, UpdateMessage, UserId}
 import com.gu.tableversions.core._
 import com.gu.tableversions.metastore.Metastore.TableChanges
 import com.gu.tableversions.metastore.{Metastore, VersionPaths}
@@ -57,7 +57,9 @@ object VersionedDataset {
       _ <- IO(VersionedDataset.writeVersionedPartitions(dataset, partitionPaths))
 
       // Commit written version
-      _ <- tableVersions.commit(TableUpdate(userId, UpdateMessage(message), Instant.now(), workingVersions))
+      _ <- tableVersions.commit(
+        table.name,
+        TableUpdate(userId, UpdateMessage(message), Instant.now(), workingVersions.map(AddPartitionVersion)))
 
       // Get latest version details and Metastore table details and sync the Metastore to match,
       // effectively switching the table to the new version.

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -4,7 +4,8 @@ import java.net.URI
 import java.time.Instant
 
 import cats.effect.IO
-import com.gu.tableversions.core.TableVersions.{AddPartitionVersion, TableUpdate, UpdateMessage, UserId}
+import com.gu.tableversions.core.TableVersions.{TableUpdate, UpdateMessage, UserId}
+import com.gu.tableversions.core.TableVersions.PartitionOperation.AddPartitionVersion
 import com.gu.tableversions.core._
 import com.gu.tableversions.metastore.Metastore.TableChanges
 import com.gu.tableversions.metastore.{Metastore, VersionPaths}

--- a/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
@@ -109,6 +109,14 @@ class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite 
     }
   }
 
+  "Getting the base path from a versioned path" should "return the same path if it's already unversioned" in {
+    versionedToBasePath(new URI("hdfs://bucket/identity")) shouldBe new URI("hdfs://bucket/identity")
+  }
+
+  it should "return strip off the version part of the path" in {
+    versionedToBasePath(new URI("hdfs://bucket/identity/v42")) shouldBe new URI("hdfs://bucket/identity")
+  }
+
   private def initPartitionedTable(table: TableDefinition): IO[Unit] = {
     val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (
                  |  `id` string,


### PR DESCRIPTION
This PR includes code for an in-memory implementation of the `TableVersions` trait, which is the service that tracks the history of table versions.

This makes the end-to-end specs pass 🎉 (with the odd bug fix), so they are enabled now.
