### PR TITLE
Make 'multiple partition columns' use case work

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
@@ -50,7 +50,7 @@ class InMemoryTableVersions[F[_]] private (allUpdates: Ref[F, TableUpdates])(imp
       allTableUpdates <- allUpdates.get
       tableUpdates <- allTableUpdates
         .get(table)
-        .fold(F.raiseError[List[TableUpdate]](new Exception(s"Table '$table' not found")))(F.pure)
+        .fold(F.raiseError[List[TableUpdate]](new Exception(s"Table '${table.fullyQualifiedName}' not found")))(F.pure)
       addedPartitions = tableUpdates.flatMap(_.partitionUpdates).collect {
         case AddPartitionVersion(partitionVersion) => partitionVersion
       }

--- a/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
@@ -3,81 +3,130 @@ package com.gu.tableversions.examples
 import java.nio.file.Path
 import java.sql.{Date, Timestamp}
 
+import cats.effect.IO
+import com.gu.tableversions.core.Partition.{ColumnValue, PartitionColumn}
+import com.gu.tableversions.core._
+import com.gu.tableversions.core.TableVersions.UserId
 import com.gu.tableversions.examples.MultiPartitionTableLoader.AdImpression
-import com.gu.tableversions.spark.SparkHiveSuite
+import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite}
 import org.scalatest.{FlatSpec, Matchers}
 
 class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite {
 
-  "Writing multiple versions of a dataset with multiple partition columns" should "produce distinct partition versions" ignore {
+  "Writing multiple versions of a dataset with multiple partition columns" should "produce distinct partition versions" in {
 
     import spark.implicits._
+    implicit val tableVersions = InMemoryTableVersions[IO].unsafeRunSync()
+    implicit val metastore = new SparkHiveMetastore[IO]()
 
-    val loader = new MultiPartitionTableLoader(s"$schema.ad_impressions", tableUri)
+    val table = TableDefinition(
+      TableName(schema, "ad_impressions"),
+      tableUri,
+      PartitionSchema(List(PartitionColumn("impression_date"), PartitionColumn("processed_date")))
+    )
+
+    val loader = new MultiPartitionTableLoader(table)
     loader.initTable()
 
     val impressionsDay1 = List(
       AdImpression("user-1", "ad-1", Timestamp.valueOf("2019-03-13 23:59:00"), Date.valueOf("2019-03-14")),
       AdImpression("user-2", "ad-1", Timestamp.valueOf("2019-03-14 00:00:10"), Date.valueOf("2019-03-14")),
-      AdImpression("user-3", "ad-2", Timestamp.valueOf("2019-03-14 00:00:10"), Date.valueOf("2019-03-14"))
+      AdImpression("user-3", "ad-2", Timestamp.valueOf("2019-03-14 00:00:20"), Date.valueOf("2019-03-14"))
     )
-    loader.insert(impressionsDay1.toDS())
+    val userId1 = UserId("test user 1")
+
+    loader.insert(impressionsDay1.toDS(), userId1, "Day 1 initial commit")
     loader.adImpressions().collect() should contain theSameElementsAs impressionsDay1
 
     partitionVersions(tableDir) shouldBe Map(
-      ("2019-03-13", "2019-03-14") -> List("v1"),
-      ("2019-03-14", "2019-03-14") -> List("v1")
+      ("impression_date=2019-03-13", "processed_date=2019-03-14") -> List("v1"),
+      ("impression_date=2019-03-14", "processed_date=2019-03-14") -> List("v1")
     )
 
     val impressionsDay2 = List(
       AdImpression("user-1", "ad-1", Timestamp.valueOf("2019-03-14 23:59:00"), Date.valueOf("2019-03-15")),
       AdImpression("user-4", "ad-3", Timestamp.valueOf("2019-03-15 00:00:10"), Date.valueOf("2019-03-15"))
     )
-    loader.insert(impressionsDay2.toDS())
+    val userId2 = UserId("test user 2")
+
+    loader.insert(impressionsDay2.toDS(), userId2, "Day 2 initial commit")
     loader.adImpressions().collect() should contain theSameElementsAs impressionsDay1 ++ impressionsDay2
 
     partitionVersions(tableDir) shouldBe Map(
-      ("2019-03-13", "2019-03-14") -> List("v1"),
-      ("2019-03-14", "2019-03-14") -> List("v1"),
-      ("2019-03-14", "2019-03-15") -> List("v1"),
-      ("2019-03-15", "2019-03-15") -> List("v1")
+      ("impression_date=2019-03-13", "processed_date=2019-03-14") -> List("v1"),
+      ("impression_date=2019-03-14", "processed_date=2019-03-14") -> List("v1"),
+      ("impression_date=2019-03-14", "processed_date=2019-03-15") -> List("v1"),
+      ("impression_date=2019-03-15", "processed_date=2019-03-15") -> List("v1")
     )
 
     // Rewrite impressions to change the content for one of the event dates
-    val impressionsDay2Updated = impressionsDay2.filter(_.user_id != "user-4")
-    loader.insert(impressionsDay2Updated.toDS())
+    val impressionsDay2Updated = impressionsDay2 ++ List(
+      AdImpression("user-5", "ad-3", Timestamp.valueOf("2019-03-15 00:01:00"), Date.valueOf("2019-03-15"))
+    )
+    loader.insert(impressionsDay2Updated.toDS(), userId1, "Day 2 update")
+
+    // Metastore should point to new partition versions.
+    // Note that the unchanged partition that was rewritten has a new version as well, there is no diffing of data
+    // to try to avoid this.
+    val tableVersionAfterUpdate = metastore.currentVersion(table.name).unsafeRunSync()
+    tableVersionAfterUpdate shouldBe
+      TableVersion(
+        List(
+          PartitionVersion(
+            Partition(List(ColumnValue(PartitionColumn("impression_date"), "2019-03-13"),
+                           ColumnValue(PartitionColumn("processed_date"), "2019-03-14"))),
+            VersionNumber(1)
+          ),
+          PartitionVersion(
+            Partition(List(ColumnValue(PartitionColumn("impression_date"), "2019-03-14"),
+                           ColumnValue(PartitionColumn("processed_date"), "2019-03-14"))),
+            VersionNumber(1)
+          ),
+          PartitionVersion(
+            Partition(List(ColumnValue(PartitionColumn("impression_date"), "2019-03-14"),
+                           ColumnValue(PartitionColumn("processed_date"), "2019-03-15"))),
+            VersionNumber(2)
+          ),
+          PartitionVersion(
+            Partition(List(ColumnValue(PartitionColumn("impression_date"), "2019-03-15"),
+                           ColumnValue(PartitionColumn("processed_date"), "2019-03-15"))),
+            VersionNumber(2)
+          )
+        ))
 
     // Query to check we see the updated version
     loader.adImpressions().collect() should contain theSameElementsAs impressionsDay1 ++ impressionsDay2Updated
 
+    // Check on-disk storage
     partitionVersions(tableDir) shouldBe Map(
-      ("2019-03-13", "2019-03-14") -> List("v1"),
-      ("2019-03-14", "2019-03-14") -> List("v1"),
-      ("2019-03-14", "2019-03-15") -> List("v1", "v2"),
-      ("2019-03-15", "2019-03-15") -> List("v1")
+      ("impression_date=2019-03-13", "processed_date=2019-03-14") -> List("v1"),
+      ("impression_date=2019-03-14", "processed_date=2019-03-14") -> List("v1"),
+      ("impression_date=2019-03-14", "processed_date=2019-03-15") -> List("v1", "v2"),
+      ("impression_date=2019-03-15", "processed_date=2019-03-15") -> List("v1", "v2")
     )
 
   }
 
   def partitionVersions(tableLocation: Path): Map[(String, String), List[String]] = {
 
-    def datePartitions(dir: Path): List[String] = {
-      val datePartitionPattern = "date=\\d\\d\\d\\d-\\d\\d-\\d\\d"
+    def datePartitions(columnName: String, dir: Path): List[String] = {
+      val datePartitionPattern = s"$columnName=\\d\\d\\d\\d-\\d\\d-\\d\\d"
       dir.toFile.list().toList.filter(_.matches(datePartitionPattern))
     }
 
     def versions(dir: Path): List[String] =
       dir.toFile.list().toList.filter(_.matches("v\\d+"))
 
-    val impressionDatePartitions: List[String] = datePartitions(tableLocation)
+    val impressionDatePartitions: List[String] = datePartitions("impression_date", tableLocation)
 
     val allPartitions: List[(String, String)] = impressionDatePartitions.flatMap(impressionDate =>
-      datePartitions(tableLocation.resolve(impressionDate)).map(processedDate => processedDate -> impressionDate))
+      datePartitions("processed_date", tableLocation.resolve(impressionDate)).map(processedDate =>
+        impressionDate -> processedDate))
 
     allPartitions
       .map {
-        case (processedDate, impressionDate) =>
-          (processedDate, impressionDate) -> versions(tableLocation.resolve(impressionDate).resolve(processedDate))
+        case (impressionDate, processedDate) =>
+          (impressionDate, processedDate) -> versions(tableLocation.resolve(impressionDate).resolve(processedDate))
       }
       .toMap
       .filter { case (_, versions) => versions.nonEmpty }

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -84,8 +84,8 @@ object VersionedDataset {
     } else {
       // Query dataset for partitions
       // NOTE: this implementation has not been optimised yet
-      val partitionColumnsList = partitionSchema.columns.map(_.name).mkString(", ")
-      val partitionsDf = dataset.selectExpr(s"$partitionColumnsList").distinct()
+      val partitionColumnsList = partitionSchema.columns.map(_.name)
+      val partitionsDf = dataset.selectExpr(partitionColumnsList: _*).distinct()
       val partitionRows = partitionsDf.collect().toList
 
       def rowToPartition(row: Row): Partition = {


### PR DESCRIPTION
The test for the use case for a table with multiple partition columns was disabled until now; this PR enables this test, updates the example loader for the multiple-partition case, and fixes the inevitable bugs that this highlighted.