### PR TITLE
Refactor model for snapshot table versions

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
@@ -42,7 +42,7 @@ object TableVersions {
       userId: UserId,
       message: UpdateMessage,
       timestamp: Instant,
-      partitionUpdates: List[PartitionOperation])
+      operations: List[TableOperation])
 
   final case class UpdateMessage(content: String) extends AnyVal
 
@@ -58,13 +58,14 @@ object TableVersions {
 
   case class ErrorMessage(value: String) extends AnyVal
 
-  /** ADT for operations on individual partitions. */
-  sealed trait PartitionOperation
+  /** ADT for operations on tables. */
+  sealed trait TableOperation
 
-  object PartitionOperation {
-    final case class InitTable(tableName: TableName, isSnapshot: Boolean) extends PartitionOperation
-    final case class AddPartitionVersion(partition: Partition, version: Version) extends PartitionOperation
-    final case class RemovePartition(partition: Partition) extends PartitionOperation
+  object TableOperation {
+    final case class InitTable(tableName: TableName, isSnapshot: Boolean) extends TableOperation
+    final case class AddTableVersion(version: Version) extends TableOperation
+    final case class AddPartitionVersion(partition: Partition, version: Version) extends TableOperation
+    final case class RemovePartition(partition: Partition) extends TableOperation
   }
 
 }

--- a/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
@@ -13,12 +13,7 @@ trait TableVersions[F[_]] {
     * Start tracking version information for given table.
     * This must be called before any other operations can be performed on this table.
     */
-  def init(
-      table: TableName,
-      isSnapshot: Boolean,
-      userId: UserId = UserId("Internal"),
-      message: UpdateMessage = UpdateMessage("Table init"),
-      timestamp: Instant = Instant.now()): F[Unit]
+  def init(table: TableName, isSnapshot: Boolean, userId: UserId, message: UpdateMessage, timestamp: Instant): F[Unit]
 
   /** Get details about partition versions in a table. */
   def currentVersion(table: TableName): F[TableVersion]

--- a/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
@@ -2,7 +2,7 @@ package com.gu.tableversions.core
 
 import java.time.Instant
 
-import com.gu.tableversions.core.TableVersions.CommitResult
+import com.gu.tableversions.core.TableVersions.{CommitResult, UpdateMessage, UserId}
 
 /**
   * This defines the interface for querying and updating table version information tracked by the system.
@@ -13,7 +13,12 @@ trait TableVersions[F[_]] {
     * Start tracking version information for given table.
     * This must be called before any other operations can be performed on this table.
     */
-  def init(table: TableName): F[Unit]
+  def init(
+      table: TableName,
+      isSnapshot: Boolean,
+      userId: UserId = UserId("Internal"),
+      message: UpdateMessage = UpdateMessage("Table init"),
+      timestamp: Instant = Instant.now()): F[Unit]
 
   /** Get details about partition versions in a table. */
   def currentVersion(table: TableName): F[TableVersion]
@@ -57,6 +62,7 @@ object TableVersions {
   sealed trait PartitionOperation
 
   object PartitionOperation {
+    final case class InitTable(tableName: TableName, isSnapshot: Boolean) extends PartitionOperation
     final case class AddPartitionVersion(partition: Partition, version: Version) extends PartitionOperation
     final case class RemovePartition(partition: Partition) extends PartitionOperation
   }

--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -68,12 +68,6 @@ final case class TableDefinition(name: TableName, location: URI, partitionSchema
 /**
   * The complete set of version information for all partitions in a table.
   */
-final case class TableVersion(partitionVersions: Map[Partition, Version])
-
-object TableVersion {
-
-  def snapshotVersion(version: Version): TableVersion = TableVersion(Map(Partition.snapshotPartition -> version))
-
-  val empty = TableVersion(Map.empty)
-
-}
+sealed trait TableVersion
+final case class PartitionedTableVersion(partitionVersions: Map[Partition, Version]) extends TableVersion
+final case class SnapshotTableVersion(version: Version) extends TableVersion

--- a/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
@@ -2,7 +2,7 @@ package com.gu.tableversions.core
 
 import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core.TableVersions.PartitionOperation._
+import com.gu.tableversions.core.TableVersions.TableOperation._
 import org.scalatest.{FlatSpec, Matchers}
 
 class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersionsSpec {

--- a/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
@@ -8,13 +8,14 @@ import org.scalatest.{FlatSpec, Matchers}
 class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersionsSpec {
 
   val date = PartitionColumn("date")
+  val emptyPartitionedTable = PartitionedTableVersion(Map.empty)
 
   "The reference implementation for the TableVersions service" should behave like tableVersionsBehaviour {
     InMemoryTableVersions[IO]
   }
 
   "Combining partition operations" should "produce an empty table version when no updates have been applied" in {
-    InMemoryTableVersions.applyUpdate(TableVersion.empty)(Nil) shouldBe TableVersion.empty
+    InMemoryTableVersions.applyPartitionUpdates(emptyPartitionedTable)(Nil) shouldBe emptyPartitionedTable
   }
 
   it should "produce the same table when an empty update is applied" in {
@@ -22,8 +23,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
       Partition(date, "2019-03-01") -> Version(3),
       Partition(date, "2019-03-02") -> Version(1)
     )
-    val tableVersion = TableVersion(partitionVersions)
-    InMemoryTableVersions.applyUpdate(tableVersion)(Nil) shouldBe tableVersion
+    val tableVersion = PartitionedTableVersion(partitionVersions)
+    InMemoryTableVersions.applyPartitionUpdates(tableVersion)(Nil) shouldBe tableVersion
   }
 
   it should "produce a version with the given partitions when no previous partition versions exist" in {
@@ -32,7 +33,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
       Partition(date, "2019-03-02") -> Version(1)
     )
     val partitionUpdates = partitionVersions.map(AddPartitionVersion.tupled).toList
-    InMemoryTableVersions.applyUpdate(TableVersion.empty)(partitionUpdates) shouldBe TableVersion(partitionVersions)
+    InMemoryTableVersions.applyPartitionUpdates(emptyPartitionedTable)(partitionUpdates) shouldBe PartitionedTableVersion(
+      partitionVersions)
   }
 
   it should "pick the latest version when an existing partition version is updated" in {
@@ -42,7 +44,7 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
       Partition(date, "2019-03-02") -> Version(2),
       Partition(date, "2019-03-03") -> Version(1)
     )
-    val initialTableVersion = TableVersion(initialPartitionVersions)
+    val initialTableVersion = PartitionedTableVersion(initialPartitionVersions)
 
     val partitionUpdates = List(AddPartitionVersion(Partition(date, "2019-03-02"), Version(3)))
 
@@ -52,7 +54,7 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
       Partition(date, "2019-03-03") -> Version(1)
     )
 
-    InMemoryTableVersions.applyUpdate(initialTableVersion)(partitionUpdates) shouldBe TableVersion(
+    InMemoryTableVersions.applyPartitionUpdates(initialTableVersion)(partitionUpdates) shouldBe PartitionedTableVersion(
       expectedPartitionVersions)
   }
 
@@ -62,7 +64,7 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
       Partition(date, "2019-03-02") -> Version(2),
       Partition(date, "2019-03-03") -> Version(1)
     )
-    val initialTableVersion = TableVersion(initialPartitionVersions)
+    val initialTableVersion = PartitionedTableVersion(initialPartitionVersions)
 
     val partitionUpdates = List(RemovePartition(Partition(date, "2019-03-02")))
 
@@ -71,7 +73,7 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
       Partition(date, "2019-03-03") -> Version(1)
     )
 
-    InMemoryTableVersions.applyUpdate(initialTableVersion)(partitionUpdates) shouldBe TableVersion(
+    InMemoryTableVersions.applyPartitionUpdates(initialTableVersion)(partitionUpdates) shouldBe PartitionedTableVersion(
       expectedPartitionVersions)
   }
 

--- a/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions.CommitResult.SuccessfulCommit
-import com.gu.tableversions.core.TableVersions.PartitionOperation.{AddPartitionVersion, RemovePartition}
+import com.gu.tableversions.core.TableVersions.TableOperation.{AddPartitionVersion, AddTableVersion, RemovePartition}
 import com.gu.tableversions.core.TableVersions._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -172,23 +172,16 @@ trait TableVersionsSpec {
         tableVersions <- emptyTableVersions
         _ <- tableVersions.init(table, isSnapshot = true)
         initialTableVersion <- tableVersions.currentVersion(table)
-
         nextVersion1 <- tableVersions.nextVersions(table, List(Partition.snapshotPartition))
         commitResult1 <- tableVersions.commit(
           table,
-          TableUpdate(userId,
-                      UpdateMessage("First commit"),
-                      timestamp(1),
-                      List(AddPartitionVersion(Partition.snapshotPartition, version1.version))))
+          TableUpdate(userId, UpdateMessage("First commit"), timestamp(1), List(AddTableVersion(version1.version))))
         currentVersion1 <- tableVersions.currentVersion(table)
 
         nextVersion2 <- tableVersions.nextVersions(table, List(Partition.snapshotPartition))
         commitResult2 <- tableVersions.commit(
           table,
-          TableUpdate(userId,
-                      UpdateMessage("Second commit"),
-                      timestamp(2),
-                      List(AddPartitionVersion(Partition.snapshotPartition, version2.version))))
+          TableUpdate(userId, UpdateMessage("Second commit"), timestamp(2), List(AddTableVersion(version2.version))))
         currentVersion2 <- tableVersions.currentVersion(table)
 
       } yield

--- a/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
@@ -22,18 +22,17 @@ trait TableVersionsSpec {
     val table = TableName("schema", "table")
     val userId = UserId("Test user")
     val date = PartitionColumn("date")
-
     it should "have an idempotent 'init' operation" in {
 
       val scenario = for {
         tableVersions <- emptyTableVersions
-        _ <- tableVersions.init(table, isSnapshot = false)
+        _ <- tableVersions.init(table, isSnapshot = false, userId, UpdateMessage("init1"), Instant.now())
         tableVersion1 <- tableVersions.currentVersion(table)
 
-        _ <- tableVersions.init(table, isSnapshot = false)
+        _ <- tableVersions.init(table, isSnapshot = false, userId, UpdateMessage("init2"), Instant.now())
         tableVersion2 <- tableVersions.currentVersion(table)
 
-        _ <- tableVersions.init(table, isSnapshot = false)
+        _ <- tableVersions.init(table, isSnapshot = false, userId, UpdateMessage("init3"), Instant.now())
         tableVersion3 <- tableVersions.currentVersion(table)
 
       } yield (tableVersion1, tableVersion2, tableVersion3)
@@ -59,7 +58,7 @@ trait TableVersionsSpec {
 
       val scenario = for {
         tableVersions <- emptyTableVersions
-        _ <- tableVersions.init(table, isSnapshot = false)
+        _ <- tableVersions.init(table, isSnapshot = false, userId, UpdateMessage("init"), Instant.now())
 
         initialTableVersion <- tableVersions.currentVersion(table)
 
@@ -110,7 +109,7 @@ trait TableVersionsSpec {
 
       val scenario = for {
         tableVersions <- emptyTableVersions
-        _ <- tableVersions.init(table, isSnapshot = false)
+        _ <- tableVersions.init(table, isSnapshot = false, userId, UpdateMessage("init"), Instant.now())
 
         // Add some partitions
         _ <- tableVersions.commit(
@@ -170,7 +169,7 @@ trait TableVersionsSpec {
 
       val scenario = for {
         tableVersions <- emptyTableVersions
-        _ <- tableVersions.init(table, isSnapshot = true)
+        _ <- tableVersions.init(table, isSnapshot = true, userId, UpdateMessage("init"), Instant.now())
         initialTableVersion <- tableVersions.currentVersion(table)
         nextVersion1 <- tableVersions.nextVersions(table, List(Partition.snapshotPartition))
         commitResult1 <- tableVersions.commit(

--- a/examples/src/main/scala/com/gu/tableversions/examples/DatePartitionedTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/DatePartitionedTableLoader.scala
@@ -38,7 +38,7 @@ class DatePartitionedTableLoader(table: TableDefinition)(
     spark.sql(ddl)
 
     // Initialise version tracking for table
-    tableVersions.init(table.name).unsafeRunSync()
+    tableVersions.init(table.name, isSnapshot = false).unsafeRunSync()
   }
 
   def pageviews(): Dataset[Pageview] =

--- a/examples/src/main/scala/com/gu/tableversions/examples/DatePartitionedTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/DatePartitionedTableLoader.scala
@@ -1,9 +1,10 @@
 package com.gu.tableversions.examples
 
 import java.sql.{Date, Timestamp}
+import java.time.Instant
 
 import cats.effect.IO
-import com.gu.tableversions.core.TableVersions.UserId
+import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core._
 import com.gu.tableversions.examples.DatePartitionedTableLoader.Pageview
 import com.gu.tableversions.metastore.Metastore
@@ -23,7 +24,7 @@ class DatePartitionedTableLoader(table: TableDefinition)(
 
   import spark.implicits._
 
-  def initTable(): Unit = {
+  def initTable(userId: UserId, message: UpdateMessage): Unit = {
     // Create table schema in metastore
     val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (
                  |  `id` string,
@@ -38,7 +39,7 @@ class DatePartitionedTableLoader(table: TableDefinition)(
     spark.sql(ddl)
 
     // Initialise version tracking for table
-    tableVersions.init(table.name, isSnapshot = false).unsafeRunSync()
+    tableVersions.init(table.name, isSnapshot = false, userId, message, Instant.now()).unsafeRunSync()
   }
 
   def pageviews(): Dataset[Pageview] =

--- a/examples/src/main/scala/com/gu/tableversions/examples/MultiPartitionTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/MultiPartitionTableLoader.scala
@@ -38,7 +38,7 @@ class MultiPartitionTableLoader(table: TableDefinition)(
     ()
 
     // Initialise version tracking for table
-    tableVersions.init(table.name).unsafeRunSync()
+    tableVersions.init(table.name, isSnapshot = false).unsafeRunSync()
   }
 
   def insert(dataset: Dataset[AdImpression], userId: UserId, message: String): Unit = {

--- a/examples/src/main/scala/com/gu/tableversions/examples/MultiPartitionTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/MultiPartitionTableLoader.scala
@@ -1,9 +1,10 @@
 package com.gu.tableversions.examples
 
 import java.sql.{Date, Timestamp}
+import java.time.Instant
 
 import cats.effect.IO
-import com.gu.tableversions.core.TableVersions.UserId
+import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core.{TableDefinition, TableVersions}
 import com.gu.tableversions.examples.MultiPartitionTableLoader.AdImpression
 import com.gu.tableversions.metastore.Metastore
@@ -23,7 +24,7 @@ class MultiPartitionTableLoader(table: TableDefinition)(
 
   import spark.implicits._
 
-  def initTable(): Unit = {
+  def initTable(userId: UserId, message: UpdateMessage): Unit = {
     val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (
                  |  `user_id` string,
                  |  `ad_id` string,
@@ -38,7 +39,7 @@ class MultiPartitionTableLoader(table: TableDefinition)(
     ()
 
     // Initialise version tracking for table
-    tableVersions.init(table.name, isSnapshot = false).unsafeRunSync()
+    tableVersions.init(table.name, isSnapshot = false, userId, message, Instant.now()).unsafeRunSync()
   }
 
   def insert(dataset: Dataset[AdImpression], userId: UserId, message: String): Unit = {

--- a/examples/src/main/scala/com/gu/tableversions/examples/SnapshotTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/SnapshotTableLoader.scala
@@ -1,13 +1,17 @@
 package com.gu.tableversions.examples
 
+import java.time.Instant
+
 import cats.effect.IO
-import com.gu.tableversions.core.TableVersions.UserId
+import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core._
 import com.gu.tableversions.examples.SnapshotTableLoader.User
 import com.gu.tableversions.metastore.Metastore
 import com.gu.tableversions.spark.VersionedDataset
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{Dataset, SparkSession}
+
+import scala.collection.script.Update
 
 /**
   * This is an example of loading data into a 'snapshot' table, that is, a table where we replace all the content
@@ -21,7 +25,7 @@ class SnapshotTableLoader(table: TableDefinition)(
 
   import spark.implicits._
 
-  def initTable(): Unit = {
+  def initTable(userId: UserId, message: UpdateMessage): Unit = {
     // Create table schema in metastore
     val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (
                  |  `id` string,
@@ -35,7 +39,7 @@ class SnapshotTableLoader(table: TableDefinition)(
     spark.sql(ddl)
 
     // Initialise version tracking for table
-    tableVersions.init(table.name, isSnapshot = true).unsafeRunSync()
+    tableVersions.init(table.name, isSnapshot = true, userId, message, Instant.now()).unsafeRunSync()
   }
 
   def users(): Dataset[User] =

--- a/examples/src/main/scala/com/gu/tableversions/examples/SnapshotTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/SnapshotTableLoader.scala
@@ -35,7 +35,7 @@ class SnapshotTableLoader(table: TableDefinition)(
     spark.sql(ddl)
 
     // Initialise version tracking for table
-    tableVersions.init(table.name).unsafeRunSync()
+    tableVersions.init(table.name, isSnapshot = true).unsafeRunSync()
   }
 
   def users(): Dataset[User] =

--- a/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
@@ -6,7 +6,7 @@ import java.sql.Timestamp
 
 import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core.TableVersions.UserId
+import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core._
 import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite}
 import org.scalatest.{FlatSpec, Matchers}
@@ -29,7 +29,9 @@ class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHi
 
     val loader =
       new DatePartitionedTableLoader(table)
-    loader.initTable()
+
+    val userId = UserId("test user")
+    loader.initTable(userId, UpdateMessage("init"))
 
     val pageviewsDay1 = List(
       Pageview("user-1", "news/politics", Timestamp.valueOf("2019-03-13 00:20:00")),
@@ -38,7 +40,6 @@ class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHi
       Pageview("user-3", "sport/football", Timestamp.valueOf("2019-03-13 21:00:00"))
     )
 
-    val userId = UserId("test user")
     loader.insert(pageviewsDay1.toDS(), userId, "Day 1 initial commit")
 
     loader.pageviews().collect() should contain theSameElementsAs pageviewsDay1

--- a/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
@@ -70,7 +70,7 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
     // to try to avoid this.
     val tableVersionAfterUpdate = metastore.currentVersion(table.name).unsafeRunSync()
     tableVersionAfterUpdate shouldBe
-      TableVersion(
+      PartitionedTableVersion(
         Map(
           Partition(List(ColumnValue(PartitionColumn("impression_date"), "2019-03-13"),
                          ColumnValue(PartitionColumn("processed_date"), "2019-03-14"))) ->

--- a/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
@@ -6,7 +6,7 @@ import java.sql.{Date, Timestamp}
 import cats.effect.IO
 import com.gu.tableversions.core.Partition.{ColumnValue, PartitionColumn}
 import com.gu.tableversions.core._
-import com.gu.tableversions.core.TableVersions.UserId
+import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.examples.MultiPartitionTableLoader.AdImpression
 import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite}
 import org.scalatest.{FlatSpec, Matchers}
@@ -26,14 +26,15 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
     )
 
     val loader = new MultiPartitionTableLoader(table)
-    loader.initTable()
+    val userId1 = UserId("test user 1")
+
+    loader.initTable(userId1, UpdateMessage("init"))
 
     val impressionsDay1 = List(
       AdImpression("user-1", "ad-1", Timestamp.valueOf("2019-03-13 23:59:00"), Date.valueOf("2019-03-14")),
       AdImpression("user-2", "ad-1", Timestamp.valueOf("2019-03-14 00:00:10"), Date.valueOf("2019-03-14")),
       AdImpression("user-3", "ad-2", Timestamp.valueOf("2019-03-14 00:00:20"), Date.valueOf("2019-03-14"))
     )
-    val userId1 = UserId("test user 1")
 
     loader.insert(impressionsDay1.toDS(), userId1, "Day 1 initial commit")
     loader.adImpressions().collect() should contain theSameElementsAs impressionsDay1

--- a/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
@@ -4,7 +4,7 @@ import java.net.URI
 import java.nio.file.Paths
 
 import cats.effect.IO
-import com.gu.tableversions.core.TableVersions.UserId
+import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core._
 import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite}
 import org.scalatest.{FlatSpec, Matchers}
@@ -24,7 +24,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
     val userId = UserId("test user")
 
     val loader = new SnapshotTableLoader(table)
-    loader.initTable()
+    loader.initTable(userId, UpdateMessage("init"))
 
     // Write the data to the table
     val identitiesDay1 = List(

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreSpec.scala
@@ -44,11 +44,11 @@ trait MetastoreSpec {
 
       val (initialVersion, firstUpdatedVersion, secondUpdatedVersion, revertedVersion) = scenario.unsafeRunSync()
 
-      initialVersion shouldBe TableVersion(Map(Partition.snapshotPartition -> Version(0)))
+      initialVersion shouldBe SnapshotTableVersion(Version(0))
       firstUpdatedVersion shouldBe
-        TableVersion(Map(Partition.snapshotPartition -> Version(1)))
+        SnapshotTableVersion(Version(1))
       secondUpdatedVersion shouldBe
-        TableVersion(Map(Partition.snapshotPartition -> Version(42)))
+        SnapshotTableVersion(Version(42))
       revertedVersion shouldEqual firstUpdatedVersion
     }
 
@@ -109,10 +109,10 @@ trait MetastoreSpec {
       val (initialVersion, versionAfterFirstUpdate, versionAfterSecondUpdate, versionAfterPartitionRemoved) =
         scenario.unsafeRunSync()
 
-      initialVersion shouldBe TableVersion.empty
+      initialVersion shouldBe PartitionedTableVersion(Map.empty)
 
       versionAfterFirstUpdate shouldBe
-        TableVersion(
+        PartitionedTableVersion(
           Map(
             Partition(dateCol, "2019-03-01") -> Version(0),
             Partition(dateCol, "2019-03-02") -> Version(1),
@@ -120,7 +120,7 @@ trait MetastoreSpec {
           ))
 
       versionAfterSecondUpdate shouldBe
-        TableVersion(
+        PartitionedTableVersion(
           Map(
             Partition(dateCol, "2019-03-01") -> Version(1),
             Partition(dateCol, "2019-03-02") -> Version(1),
@@ -128,7 +128,7 @@ trait MetastoreSpec {
           ))
 
       versionAfterPartitionRemoved shouldBe
-        TableVersion(
+        PartitionedTableVersion(
           Map(
             Partition(dateCol, "2019-03-01") -> Version(1),
             Partition(dateCol, "2019-03-03") -> Version(2)

--- a/spark/src/main/scala/com/gu/tableversions/spark/SparkHiveMetastore.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/SparkHiveMetastore.scala
@@ -32,12 +32,12 @@ class SparkHiveMetastore[F[_]](implicit spark: SparkSession, F: Sync[F]) extends
       partitionVersions = partitionLocations.map {
         case (partition, location) => parsePartition(partition) -> parseVersion(location)
       }
-    } yield TableVersion(partitionVersions.toMap)
+    } yield PartitionedTableVersion(partitionVersions.toMap)
 
     val snapshotTableVersion: F[TableVersion] = for {
       tableLocation <- findTableLocation(table)
       versionNumber = parseVersion(tableLocation)
-    } yield TableVersion(Map(Partition.snapshotPartition -> versionNumber))
+    } yield SnapshotTableVersion(versionNumber)
 
     // Choose the calculation to perform based on whether we have a partitioned table or not
     isPartitioned(table).flatMap(partitioned => if (partitioned) partitionedTableVersion else snapshotTableVersion)


### PR DESCRIPTION
This PR contains some refactorings in the core model in and around the `TableVersions` trait:

- Introduce `TableVersion` ADT with types for snapshot and partitioned table cases. We found that there are special cases for handling versions for the different types of tables, and encoding this in the types makes things more clear.
- Add `InitTable` operation. We found that this was necessary to let the implementation know which type of table it has in order to return the appropriate `TableVersion` type. But it also seems useful in that the event sequence for a table now fully describes the initialisation of the table as well as version updates.
- Add `AddTableVersion` operation for snapshot tables. This is to distinguish updates to the version of snapshot tables as opposed to updates to versions of partitions in a partitioned table.

