### PR TITLE
Use UUID strings for versions instead of incremental numbers

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/InMemoryTableVersions.scala
@@ -49,54 +49,10 @@ class InMemoryTableVersions[F[_]] private (allUpdates: Ref[F, TableUpdates])(imp
       else
         InMemoryTableVersions.applyPartitionUpdates(PartitionedTableVersion(Map.empty))(operations)
 
-  def isSnapShot(operations: List[TableOperation]) = operations match {
+  private def isSnapShot(operations: List[TableOperation]) = operations match {
     case InitTable(_, isSnapshot) :: _ => isSnapshot
     case _                             => throw new IllegalArgumentException("First operation should be InitTable")
   }
-
-  override def nextVersions(table: TableName, partitions: List[Partition]): F[Map[Partition, Version]] =
-    if (partitions == List(Partition.snapshotPartition)) {
-      for {
-        allTableUpdates <- allUpdates.get
-        tableUpdates <- allTableUpdates
-          .get(table)
-          .fold(F.raiseError[List[TableUpdate]](new Exception(s"Table '${table.fullyQualifiedName}' not found")))(
-            F.pure)
-        tableVersions = tableUpdates.flatMap(_.operations).collect {
-          case AddTableVersion(version) => version
-        }
-        lastVersion = tableVersions.lastOption.getOrElse(Version(0))
-      } yield Map(Partition.snapshotPartition -> Version(lastVersion.number + 1))
-    } else {
-      def maxVersions(operations: List[(Partition, Version)]): Map[Partition, Version] =
-        operations.foldLeft(Map.empty[Partition, Version]) {
-          case (agg, (partition, partitionVersion)) =>
-            val previousVersion =
-              agg.getOrElse(partition, Version(0))
-            val maxVersion =
-              if (previousVersion.number > partitionVersion.number) previousVersion else partitionVersion
-
-            agg + (partition -> maxVersion)
-        }
-
-      def nextVersion(previousVersion: Option[Version]): Version =
-        previousVersion
-          .map(v => Version(v.number + 1))
-          .getOrElse(Version(1))
-
-      for {
-        allTableUpdates <- allUpdates.get
-        tableUpdates <- allTableUpdates
-          .get(table)
-          .fold(F.raiseError[List[TableUpdate]](new Exception(s"Table '${table.fullyQualifiedName}' not found")))(
-            F.pure)
-        addedPartitions = tableUpdates.flatMap(_.operations).collect {
-          case AddPartitionVersion(partition, version) => (partition, version)
-        }
-        maxUsedVersions = maxVersions(addedPartitions)
-        nextVersions = partitions.map(p => p -> nextVersion(maxUsedVersions.get(p)))
-      } yield nextVersions.toMap
-    }
 
   override def commit(table: TableName, update: TableVersions.TableUpdate): F[TableVersions.CommitResult] = {
 
@@ -130,7 +86,7 @@ object InMemoryTableVersions {
     val versions = operations.collect {
       case AddTableVersion(version) => version
     }
-    SnapshotTableVersion(versions.lastOption.getOrElse(Version(0)))
+    SnapshotTableVersion(versions.lastOption.getOrElse(Version.Unversioned))
   }
 
   /**

--- a/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/TableVersions.scala
@@ -18,9 +18,6 @@ trait TableVersions[F[_]] {
   /** Get details about partition versions in a table. */
   def currentVersion(table: TableName): F[TableVersion]
 
-  /** Get a description of which version to write to next for the given partitions of a table. */
-  def nextVersions(table: TableName, partitions: List[Partition]): F[Map[Partition, Version]]
-
   /**
     * Update partition versions to the given versions.
     * This performs no checking if data has been written to the associated paths but it will verify that these versions

--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -1,6 +1,11 @@
 package com.gu.tableversions.core
 
 import java.net.URI
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+import cats.effect.IO
 
 /**
   * A Partition represents a concrete partition of a table, i.e. a partition column with a specific value.
@@ -53,7 +58,23 @@ object PartitionSchema {
 // Versions
 //
 
-final case class Version(number: Int) extends AnyVal
+final case class Version(label: String) extends AnyVal
+
+object Version {
+
+  /** Generator for versions using a timestamp + UUID format */
+  implicit val generateVersion: IO[Version] = IO {
+    val versionString = UUID.randomUUID().toString
+    val timestamp = formatter.format(LocalDateTime.now())
+    Version(s"$timestamp-$versionString")
+  }
+
+  val TimestampAndUuidRegex = """(\d{8}-\d{6}-.*)""".r
+
+  private val formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+
+  val Unversioned = Version("Unversioned")
+}
 
 //
 // Tables

--- a/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
@@ -20,8 +20,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
 
   it should "produce the same table when an empty update is applied" in {
     val partitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-02") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-02") -> Version("1")
     )
     val tableVersion = PartitionedTableVersion(partitionVersions)
     InMemoryTableVersions.applyPartitionUpdates(tableVersion)(Nil) shouldBe tableVersion
@@ -29,8 +29,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
 
   it should "produce a version with the given partitions when no previous partition versions exist" in {
     val partitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-02") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-02") -> Version("1")
     )
     val partitionUpdates = partitionVersions.map(AddPartitionVersion.tupled).toList
     InMemoryTableVersions.applyPartitionUpdates(emptyPartitionedTable)(partitionUpdates) shouldBe PartitionedTableVersion(
@@ -40,18 +40,18 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
   it should "pick the latest version when an existing partition version is updated" in {
 
     val initialPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-02") -> Version(2),
-      Partition(date, "2019-03-03") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-02") -> Version("2"),
+      Partition(date, "2019-03-03") -> Version("1")
     )
     val initialTableVersion = PartitionedTableVersion(initialPartitionVersions)
 
-    val partitionUpdates = List(AddPartitionVersion(Partition(date, "2019-03-02"), Version(3)))
+    val partitionUpdates = List(AddPartitionVersion(Partition(date, "2019-03-02"), Version("3")))
 
     val expectedPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-02") -> Version(3),
-      Partition(date, "2019-03-03") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-02") -> Version("3"),
+      Partition(date, "2019-03-03") -> Version("1")
     )
 
     InMemoryTableVersions.applyPartitionUpdates(initialTableVersion)(partitionUpdates) shouldBe PartitionedTableVersion(
@@ -60,17 +60,17 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
 
   it should "remove an existing partition" in {
     val initialPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-02") -> Version(2),
-      Partition(date, "2019-03-03") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-02") -> Version("2"),
+      Partition(date, "2019-03-03") -> Version("1")
     )
     val initialTableVersion = PartitionedTableVersion(initialPartitionVersions)
 
     val partitionUpdates = List(RemovePartition(Partition(date, "2019-03-02")))
 
     val expectedPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-03") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-03") -> Version("1")
     )
 
     InMemoryTableVersions.applyPartitionUpdates(initialTableVersion)(partitionUpdates) shouldBe PartitionedTableVersion(

--- a/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
@@ -4,6 +4,7 @@ import java.net.URI
 
 import com.gu.tableversions.core.Partition.PartitionColumn
 import org.scalatest.{FlatSpec, Matchers}
+import cats.implicits._
 
 class ModelSpec extends FlatSpec with Matchers {
 
@@ -32,6 +33,21 @@ class ModelSpec extends FlatSpec with Matchers {
 
     partition.resolvePath(tableLocation) shouldBe new URI(
       "s3://bucket/data/event_date=2019-01-20/processed_date=2019-01-21/")
+  }
+
+  "Generating versions" should "produce valid labels" in {
+    val version = Version.generateVersion.unsafeRunSync()
+    version.label should fullyMatch regex Version.TimestampAndUuidRegex
+  }
+
+  it should "produce unique labels" in {
+    val versions = (1 to 100).map(_ => Version.generateVersion).toList.sequence.unsafeRunSync()
+    versions.distinct.size shouldBe versions.size
+  }
+
+  "The label format regex" should "match valid labels" in {
+    val validVersionLabel = "20181102-235900-4920d06f-2233-4b4a-9521-8e730eee89c5"
+    validVersionLabel should fullyMatch regex Version.TimestampAndUuidRegex
   }
 
 }

--- a/examples/src/main/scala/com/gu/tableversions/examples/DatePartitionedTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/DatePartitionedTableLoader.scala
@@ -19,6 +19,7 @@ import org.apache.spark.sql.{Dataset, SparkSession}
 class DatePartitionedTableLoader(table: TableDefinition)(
     implicit tableVersions: TableVersions[IO],
     metastore: Metastore[IO],
+    generateVersion: IO[Version],
     spark: SparkSession)
     extends LazyLogging {
 

--- a/examples/src/main/scala/com/gu/tableversions/examples/MultiPartitionTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/MultiPartitionTableLoader.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 
 import cats.effect.IO
 import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
-import com.gu.tableversions.core.{TableDefinition, TableVersions}
+import com.gu.tableversions.core.{TableDefinition, TableVersions, Version}
 import com.gu.tableversions.examples.MultiPartitionTableLoader.AdImpression
 import com.gu.tableversions.metastore.Metastore
 import com.gu.tableversions.spark.VersionedDataset
@@ -19,6 +19,7 @@ import org.apache.spark.sql.{Dataset, SparkSession}
 class MultiPartitionTableLoader(table: TableDefinition)(
     implicit tableVersions: TableVersions[IO],
     metastore: Metastore[IO],
+    generateVersion: IO[Version],
     spark: SparkSession)
     extends LazyLogging {
 
@@ -44,6 +45,7 @@ class MultiPartitionTableLoader(table: TableDefinition)(
 
   def insert(dataset: Dataset[AdImpression], userId: UserId, message: String): Unit = {
     import VersionedDataset._
+    import Version._
 
     val (latestVersion, metastoreChanges) = dataset.versionedInsertInto(table, userId, message)
 

--- a/examples/src/main/scala/com/gu/tableversions/examples/SnapshotTableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/SnapshotTableLoader.scala
@@ -20,6 +20,7 @@ import scala.collection.script.Update
 class SnapshotTableLoader(table: TableDefinition)(
     implicit tableVersions: TableVersions[IO],
     metastore: Metastore[IO],
+    generateVersion: IO[Version],
     spark: SparkSession)
     extends LazyLogging {
 

--- a/metastore/src/main/scala/com/gu/tableversions/metastore/VersionPaths.scala
+++ b/metastore/src/main/scala/com/gu/tableversions/metastore/VersionPaths.scala
@@ -10,25 +10,25 @@ import com.gu.tableversions.core.{Partition, Version}
 object VersionPaths {
 
   /**
-    * @return the fully resolved path for collection of versioned path
+    * @return the fully resolved paths for each partitions, derived from the table location and version
     */
   def resolveVersionedPartitionPaths(
-      partitionVersions: Map[Partition, Version],
+      partitions: List[Partition],
+      version: Version,
       tableLocation: URI): Map[Partition, URI] = {
 
-    partitionVersions.map {
-      case (partition, version) =>
-        val partitionBasePath = partition.resolvePath(tableLocation)
-        partition -> pathFor(partitionBasePath, version)
-    }
+    partitions.map { partition =>
+      val partitionBasePath = partition.resolvePath(tableLocation)
+      partition -> pathFor(partitionBasePath, version)
+    }.toMap
   }
 
   /**
     * @return a path for a given partition version and base path
     */
-  def pathFor(partitionPath: URI, newVersion: Version): URI = {
+  def pathFor(partitionPath: URI, version: Version): URI = {
     def normalised(path: String): String = if (path.endsWith("/")) path else path + "/"
-    def versioned(path: String): String = if (newVersion.number <= 0) path else s"${path}v${newVersion.number}"
+    def versioned(path: String): String = s"$path${version.label}"
     new URI(versioned(normalised(partitionPath.toString)))
   }
 

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreObjectSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreObjectSpec.scala
@@ -13,23 +13,23 @@ class MetastoreObjectSpec extends FlatSpec with Matchers {
     val oldVersion = PartitionedTableVersion(Map.empty)
 
     val newPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-03") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-03") -> Version("1")
     )
     val newVersion = PartitionedTableVersion(newPartitionVersions)
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 
     changes.operations should contain theSameElementsAs List(
-      AddPartition(Partition(date, "2019-03-01"), Version(3)),
-      AddPartition(Partition(date, "2019-03-03"), Version(1))
+      AddPartition(Partition(date, "2019-03-01"), Version("3")),
+      AddPartition(Partition(date, "2019-03-03"), Version("1"))
     )
   }
 
   it should "produce operations to remove deleted partitions" in {
     val oldPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version(3),
-      Partition(date, "2019-03-03") -> Version(1)
+      Partition(date, "2019-03-01") -> Version("3"),
+      Partition(date, "2019-03-03") -> Version("1")
     )
     val oldVersion = PartitionedTableVersion(oldPartitionVersions)
 
@@ -44,29 +44,29 @@ class MetastoreObjectSpec extends FlatSpec with Matchers {
   }
 
   it should "produce operations to update the versions of existing partitions" in {
-    val oldPartitionVersions = Map(Partition(date, "2019-03-01") -> Version(1))
+    val oldPartitionVersions = Map(Partition(date, "2019-03-01") -> Version("1"))
     val oldVersion = PartitionedTableVersion(oldPartitionVersions)
 
-    val newPartitionVersions = Map(Partition(date, "2019-03-01") -> Version(2))
+    val newPartitionVersions = Map(Partition(date, "2019-03-01") -> Version("2"))
     val newVersion = PartitionedTableVersion(newPartitionVersions)
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 
     changes.operations should contain theSameElementsAs List(
-      UpdatePartitionVersion(Partition(date, "2019-03-01"), Version(2)))
+      UpdatePartitionVersion(Partition(date, "2019-03-01"), Version("2")))
   }
 
   it should "produce an operation to update the version of a table for an updated snapshot table version" in {
-    val oldVersion = SnapshotTableVersion(Version(1))
-    val newVersion = SnapshotTableVersion(Version(2))
+    val oldVersion = SnapshotTableVersion(Version("1"))
+    val newVersion = SnapshotTableVersion(Version("2"))
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 
-    changes.operations should contain theSameElementsAs List(UpdateTableVersion(Version(2)))
+    changes.operations should contain theSameElementsAs List(UpdateTableVersion(Version("2")))
   }
 
   it should "produce no change for a snapshot table with the same version" in {
-    val version = SnapshotTableVersion(Version(1))
+    val version = SnapshotTableVersion(Version("1"))
 
     val changes = Metastore.computeChanges(version, version)
 

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/VersionPathsSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/VersionPathsSpec.scala
@@ -8,47 +8,44 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class VersionPathsSpec extends FlatSpec with Matchers {
 
-  "Resolving a path with version 0" should "produce the original path" in {
-    VersionPaths.pathFor(new URI("s3://foo/bar/"), Version(0)) shouldBe new URI("s3://foo/bar/")
-  }
-
   it should "return a normalised path if given a path that doesn't end in a '/'" in {
-    VersionPaths.pathFor(new URI("s3://foo/bar"), Version(0)) shouldBe new URI("s3://foo/bar/")
+    VersionPaths.pathFor(new URI("s3://foo/bar"), Version("version-label")) shouldBe new URI(
+      "s3://foo/bar/version-label")
   }
 
   "Resolving path with a non-0 version number" should "have the version string appended as a folder" in {
-    VersionPaths.pathFor(new URI("s3://foo/bar/"), Version(42)) shouldBe new URI("s3://foo/bar/v42")
+    VersionPaths.pathFor(new URI("s3://foo/bar/"), Version("version-label")) shouldBe new URI(
+      "s3://foo/bar/version-label")
   }
 
   "Resolving versioned paths" should "return paths relative to the table location, using the defined versioning scheme" in {
     val tableLocation = new URI("s3://bucket/data/")
 
-    val partitionVersions = Map(
-      Partition(PartitionColumn("date"), "2019-01-15") -> Version(5),
-      Partition(PartitionColumn("date"), "2019-01-16") -> Version(1),
-      Partition(PartitionColumn("date"), "2019-01-18") -> Version(3)
+    val partitions = List(
+      Partition(PartitionColumn("date"), "2019-01-15"),
+      Partition(PartitionColumn("date"), "2019-01-16"),
+      Partition(PartitionColumn("date"), "2019-01-18")
     )
 
-    val partitionPaths = VersionPaths.resolveVersionedPartitionPaths(partitionVersions, tableLocation)
+    val partitionPaths = VersionPaths.resolveVersionedPartitionPaths(partitions, Version("test-version"), tableLocation)
 
     partitionPaths shouldBe Map(
-      Partition(PartitionColumn("date"), "2019-01-15") -> new URI("s3://bucket/data/date=2019-01-15/v5"),
-      Partition(PartitionColumn("date"), "2019-01-16") -> new URI("s3://bucket/data/date=2019-01-16/v1"),
-      Partition(PartitionColumn("date"), "2019-01-18") -> new URI("s3://bucket/data/date=2019-01-18/v3")
+      Partition(PartitionColumn("date"), "2019-01-15") -> new URI("s3://bucket/data/date=2019-01-15/test-version"),
+      Partition(PartitionColumn("date"), "2019-01-16") -> new URI("s3://bucket/data/date=2019-01-16/test-version"),
+      Partition(PartitionColumn("date"), "2019-01-18") -> new URI("s3://bucket/data/date=2019-01-18/test-version")
     )
   }
 
   it should "correctly resolved paths even if the base bath doesn't have a trailing slash" in {
     val tableLocation = new URI("s3://bucket/data")
 
-    val partitionVersions = Map(
-      Partition(PartitionColumn("date"), "2019-01-15") -> Version(5)
-    )
+    val partitions = List(Partition(PartitionColumn("date"), "2019-01-15"))
 
-    val partitionPaths = VersionPaths.resolveVersionedPartitionPaths(partitionVersions, tableLocation)
+    val partitionPaths =
+      VersionPaths.resolveVersionedPartitionPaths(partitions, Version("test-version"), tableLocation)
 
     partitionPaths shouldBe Map(
-      Partition(PartitionColumn("date"), "2019-01-15") -> new URI("s3://bucket/data/date=2019-01-15/v5")
+      Partition(PartitionColumn("date"), "2019-01-15") -> new URI("s3://bucket/data/date=2019-01-15/test-version")
     )
   }
 


### PR DESCRIPTION
This changes `Version`s to contain opaque strings instead of incremental numbers. We define a format for version strings that contains a timestamp and a UUID. We also remove the `nextVersion` method on the `TableVersion` interface as clients can now generate their own `Version`s as needed.

This means that written partitions will be completely immutable as code will generate new `Version`s every time it attempts to write data. It also ensures two concurrent clients can't attempt to write to the same path.