### PR TITLE
Remove usage of empty Partition value to handle snapshot table case

### DIFF
--- a/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
@@ -10,11 +10,6 @@ class ModelSpec extends FlatSpec with Matchers {
 
   val tableLocation = new URI("s3://bucket/data/")
 
-  "Resolving the path of a partition for an empty partition list" should "return the table location itself" in {
-    val partition = Partition(Nil)
-    partition.resolvePath(tableLocation) shouldBe tableLocation
-  }
-
   "Resolving the path of a partition with a single partition column" should "produce path relative to the table location" in {
     val partition = Partition(List(Partition.ColumnValue(PartitionColumn("date"), "2019-01-20")))
     partition.resolvePath(tableLocation) shouldBe new URI("s3://bucket/data/date=2019-01-20/")

--- a/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
@@ -2,29 +2,28 @@ package com.gu.tableversions.core
 
 import java.net.URI
 
+import cats.implicits._
 import com.gu.tableversions.core.Partition.PartitionColumn
 import org.scalatest.{FlatSpec, Matchers}
-import cats.implicits._
 
 class ModelSpec extends FlatSpec with Matchers {
 
   val tableLocation = new URI("s3://bucket/data/")
 
   "Resolving the path of a partition with a single partition column" should "produce path relative to the table location" in {
-    val partition = Partition(List(Partition.ColumnValue(PartitionColumn("date"), "2019-01-20")))
+    val partition = Partition(Partition.ColumnValue(PartitionColumn("date"), "2019-01-20"))
     partition.resolvePath(tableLocation) shouldBe new URI("s3://bucket/data/date=2019-01-20/")
   }
 
   it should "work even if the table location doesn't have a trailing slash" in {
     val tableLocation = new URI("s3://bucket/data")
-    val partition = Partition(List(Partition.ColumnValue(PartitionColumn("date"), "2019-01-20")))
+    val partition = Partition(Partition.ColumnValue(PartitionColumn("date"), "2019-01-20"))
     partition.resolvePath(tableLocation) shouldBe new URI("s3://bucket/data/date=2019-01-20/")
   }
 
   "Resolving the path of a partition with multiple partition columns" should "produce path relative to the table location" in {
-    val partition = Partition(
-      List(Partition.ColumnValue(PartitionColumn("event_date"), "2019-01-20"),
-           Partition.ColumnValue(PartitionColumn("processed_date"), "2019-01-21")))
+    val partition = Partition(Partition.ColumnValue(PartitionColumn("event_date"), "2019-01-20"),
+                              Partition.ColumnValue(PartitionColumn("processed_date"), "2019-01-21"))
 
     partition.resolvePath(tableLocation) shouldBe new URI(
       "s3://bucket/data/event_date=2019-01-20/processed_date=2019-01-21/")

--- a/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/TableVersionsSpec.scala
@@ -208,7 +208,7 @@ trait TableVersionsSpec {
           TableUpdate(userId,
                       UpdateMessage("Commit initial partitions"),
                       timestamp(1),
-                      List(AddPartitionVersion(Partition.snapshotPartition, Version("1"))))
+                      List(AddTableVersion(Version("1"))))
         )
       } yield version
 

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -103,11 +103,12 @@ object VersionedDataset {
       val partitionColumnValues: List[(Partition.PartitionColumn, String)] =
         partitionSchema.columns zip row.toSeq.map(_.toString)
 
-      val columnValues: List[Partition.ColumnValue] = partitionColumnValues.map {
-        case (partitionColumn, value) => Partition.ColumnValue(partitionColumn, value)
-      }
+      val columnValues = partitionColumnValues.map(Partition.ColumnValue.tupled)
 
-      Partition(columnValues)
+      columnValues match {
+        case head :: tail => Partition(head, tail: _*)
+        case _            => throw new Exception("Empty list of partitions not valid for partitioned table")
+      }
     }
 
     partitionRows.map(rowToPartition)

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -5,11 +5,12 @@ import java.time.Instant
 
 import cats.effect.IO
 import com.gu.tableversions.core.TableVersions.TableOperation.{AddPartitionVersion, AddTableVersion}
-import com.gu.tableversions.core.TableVersions.{TableUpdate, UpdateMessage, UserId}
+import com.gu.tableversions.core.TableVersions.{TableOperation, TableUpdate, UpdateMessage, UserId}
 import com.gu.tableversions.core._
 import com.gu.tableversions.metastore.Metastore.TableChanges
 import com.gu.tableversions.metastore.{Metastore, VersionPaths}
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import cats.implicits._
 
 /**
   * Code for writing Spark datasets to storage in a version-aware manner, taking in version information,
@@ -45,26 +46,34 @@ object VersionedDataset {
       message: String)(
       implicit tableVersions: TableVersions[IO],
       metastore: Metastore[IO],
-      generateVersion: IO[Version]): IO[(TableVersion, TableChanges)] =
-    for {
-      // Find the partition values in the given dataset
-      datasetPartitions <- IO(VersionedDataset.partitionValues(dataset, table.partitionSchema)(dataset.sparkSession))
+      generateVersion: IO[Version]): IO[(TableVersion, TableChanges)] = {
 
+    def writePartitionedDataset(version: Version): IO[List[TableOperation]] =
+      for {
+        // Find the partition values in the given dataset
+        datasetPartitions <- IO(VersionedDataset.partitionValues(dataset, table.partitionSchema)(dataset.sparkSession))
+
+        // Resolve the path that each partition should be written to, based on their version
+        partitionPaths = VersionPaths.resolveVersionedPartitionPaths(datasetPartitions, version, table.location)
+
+        // Write Spark dataset to the versioned path
+        _ <- IO(VersionedDataset.writeVersionedPartitions(dataset, partitionPaths))
+
+      } yield datasetPartitions.map(partition => AddPartitionVersion(partition, version))
+
+    def writeSnapshotDataset(version: Version): IO[List[TableOperation]] = {
+      val path = VersionPaths.pathFor(table.location, version)
+      IO(dataset.write.parquet(path.toString)).as(List(AddTableVersion(version)))
+    }
+
+    for {
       // Get next version to use for all partitions
       newVersion <- generateVersion
 
-      // Resolve the path that each partition should be written to, based on their version
-      partitionPaths = VersionPaths.resolveVersionedPartitionPaths(datasetPartitions, newVersion, table.location)
-
-      // Write Spark dataset to the versioned path
-      _ <- IO(VersionedDataset.writeVersionedPartitions(dataset, partitionPaths))
+      operations <- if (table.isSnapshot) writeSnapshotDataset(newVersion) else writePartitionedDataset(newVersion)
 
       // Commit written version
-      _ <- tableVersions.commit(table.name,
-                                TableUpdate(userId,
-                                            UpdateMessage(message),
-                                            Instant.now(),
-                                            operationsForPartitions(datasetPartitions, newVersion)))
+      _ <- tableVersions.commit(table.name, TableUpdate(userId, UpdateMessage(message), Instant.now(), operations))
 
       // Get latest version details and Metastore table details and sync the Metastore to match,
       // effectively switching the table to the new version.
@@ -77,13 +86,6 @@ object VersionedDataset {
       _ <- metastore.update(table.name, metastoreUpdate)
 
     } yield (latestTableVersion, metastoreUpdate)
-
-  private def operationsForPartitions(
-      partitions: List[Partition],
-      version: Version): List[TableVersions.TableOperation] = {
-    if (partitions == List(Partition.snapshotPartition))
-      List(AddTableVersion(version))
-    else partitions.map(partition => AddPartitionVersion(partition, version))
   }
 
   /**
@@ -91,28 +93,24 @@ object VersionedDataset {
     */
   private[spark] def partitionValues[T](dataset: Dataset[T], partitionSchema: PartitionSchema)(
       implicit spark: SparkSession): List[Partition] = {
-    if (partitionSchema == PartitionSchema.snapshot) {
-      List(Partition.snapshotPartition)
-    } else {
-      // Query dataset for partitions
-      // NOTE: this implementation has not been optimised yet
-      val partitionColumnsList = partitionSchema.columns.map(_.name)
-      val partitionsDf = dataset.selectExpr(partitionColumnsList: _*).distinct()
-      val partitionRows = partitionsDf.collect().toList
+    // Query dataset for partitions
+    // NOTE: this implementation has not been optimised yet
+    val partitionColumnsList = partitionSchema.columns.map(_.name)
+    val partitionsDf = dataset.selectExpr(partitionColumnsList: _*).distinct()
+    val partitionRows = partitionsDf.collect().toList
 
-      def rowToPartition(row: Row): Partition = {
-        val partitionColumnValues: List[(Partition.PartitionColumn, String)] =
-          partitionSchema.columns zip row.toSeq.map(_.toString)
+    def rowToPartition(row: Row): Partition = {
+      val partitionColumnValues: List[(Partition.PartitionColumn, String)] =
+        partitionSchema.columns zip row.toSeq.map(_.toString)
 
-        val columnValues: List[Partition.ColumnValue] = partitionColumnValues.map {
-          case (partitionColumn, value) => Partition.ColumnValue(partitionColumn, value)
-        }
-
-        Partition(columnValues)
+      val columnValues: List[Partition.ColumnValue] = partitionColumnValues.map {
+        case (partitionColumn, value) => Partition.ColumnValue(partitionColumn, value)
       }
 
-      partitionRows.map(rowToPartition)
+      Partition(columnValues)
     }
+
+    partitionRows.map(rowToPartition)
   }
 
   /**
@@ -129,10 +127,7 @@ object VersionedDataset {
       }
 
     val datasetsWithPaths: Map[Dataset[T], URI] =
-      if (partitionPaths.keySet == Set(Partition.snapshotPartition))
-        Map(dataset -> partitionPaths.values.head)
-      else
-        partitionPaths.map { case (partition, path) => filteredForPartition(partition) -> path }
+      partitionPaths.map { case (partition, path) => filteredForPartition(partition) -> path }
 
     datasetsWithPaths.foreach {
       case (datasetForPartition, partitionPath) =>

--- a/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
@@ -40,16 +40,14 @@ class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite 
   "Parsing a valid partition string" should "produce the expected values" in {
     val testData = Table(
       ("partitionStr", "expected"),
-      ("date=2019-01-31", Partition(List(ColumnValue(PartitionColumn("date"), "2019-01-31")))),
+      ("date=2019-01-31", Partition(ColumnValue(PartitionColumn("date"), "2019-01-31"))),
       ("event_date=2019-01-30/processed_date=2019-01-31",
-       Partition(
-         List(ColumnValue(PartitionColumn("event_date"), "2019-01-30"),
-              ColumnValue(PartitionColumn("processed_date"), "2019-01-31")))),
+       Partition(ColumnValue(PartitionColumn("event_date"), "2019-01-30"),
+                 ColumnValue(PartitionColumn("processed_date"), "2019-01-31"))),
       ("year=2019/month=01/day=31",
-       Partition(
-         List(ColumnValue(PartitionColumn("year"), "2019"),
-              ColumnValue(PartitionColumn("month"), "01"),
-              ColumnValue(PartitionColumn("day"), "31"))))
+       Partition(ColumnValue(PartitionColumn("year"), "2019"),
+                 ColumnValue(PartitionColumn("month"), "01"),
+                 ColumnValue(PartitionColumn("day"), "31")))
     )
 
     forAll(testData) { (partitionStr: String, expected: Partition) =>
@@ -78,9 +76,9 @@ class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite 
     val testData = Table(
       ("partition", "expected partition expression"),
       Partition(
-        List(ColumnValue(PartitionColumn("event_date"), "2019-01-30"),
-             ColumnValue(PartitionColumn("processed_date"), "2019-01-31"))) -> "(event_date='2019-01-30',processed_date='2019-01-31')",
-      Partition(List(ColumnValue(PartitionColumn("date"), "2019-01-31"))) -> "(date='2019-01-31')"
+        ColumnValue(PartitionColumn("event_date"), "2019-01-30"),
+        ColumnValue(PartitionColumn("processed_date"), "2019-01-31")) -> "(event_date='2019-01-30',processed_date='2019-01-31')",
+      Partition(ColumnValue(PartitionColumn("date"), "2019-01-31")) -> "(date='2019-01-31')"
     )
 
     forAll(testData) { (partition, expectedExpr) =>


### PR DESCRIPTION
We used to indicate a snapshot table by having a `Partition` with an empty list of columns. It turns out that this wasn't really useful as we mostly needed special cases to handle snapshot vs. partitioned tables anyway. So we've removed this 'magic' value and have separate functions for handling different cases instead.