### PR TITLE
Refactor Version type to require a defined timestamp + UUID format

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/Version.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/Version.scala
@@ -1,0 +1,60 @@
+package com.gu.tableversions.core
+
+import java.time.{Instant, LocalDateTime, ZoneId}
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+import cats.effect.IO
+import cats.syntax.either._
+
+import scala.util.Try
+
+/**
+  * Type that represents a valid version, as used by tables and partitions.
+  */
+final case class Version(timestamp: Instant, uuid: UUID) {
+
+  import Version._
+
+  def label: String = {
+    val versionString = uuid
+    val localDateTime = LocalDateTime.ofInstant(timestamp, ZoneId.of("UTC"))
+    val timestampStr = timestampFormatter.format(localDateTime)
+    s"$timestampStr-$versionString"
+  }
+
+}
+
+object Version {
+
+  val Unversioned = Version(Instant.MIN, new UUID(0L, 0L))
+
+  /** Generator for versions using a timestamp + UUID format */
+  implicit val generateVersion: IO[Version] =
+    IO { Version(Instant.now(), UUID.randomUUID()) }
+
+  /** Regex that can be used to recognise a valid format string. */
+  val TimestampAndUuidRegex = """(\d{8}-\d{6}.\d{9})-(.*)""".r
+
+  private val timestampFormatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.nnnnnnnnn")
+
+  /**
+    * Try to parse a Version object from a string.
+    */
+  def parse(label: String): Either[Throwable, Version] = {
+
+    def parseVersionFields(label: String): Either[Throwable, (String, String)] = label match {
+      case Version.TimestampAndUuidRegex(timestampStr, uuidStr) => Right((timestampStr, uuidStr))
+      case _                                                    => Left(new IllegalArgumentException(s"invalid version label format $label"))
+    }
+
+    for {
+      versionFields <- parseVersionFields(label)
+      (timestampStr, uuidStr) = versionFields
+      uuid <- Either.fromTry(Try(UUID.fromString(uuidStr)))
+      zonedDateTime = LocalDateTime.parse(timestampStr, Version.timestampFormatter).atZone(ZoneId.of("UTC"))
+      version = Version(Instant.from(zonedDateTime), uuid)
+    } yield version
+  }
+
+}

--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -1,12 +1,8 @@
 package com.gu.tableversions.core
 
 import java.net.URI
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.util.UUID
 
 import cats.data.NonEmptyList
-import cats.effect.IO
 
 /**
   * A Partition represents a concrete partition of a table, i.e. a partition column with a specific value.
@@ -50,28 +46,6 @@ object PartitionSchema {
   // The special case partition that represents the root partition of a snapshot table.
   val snapshot: PartitionSchema = PartitionSchema(Nil)
 
-}
-
-//
-// Versions
-//
-
-final case class Version(label: String) extends AnyVal
-
-object Version {
-
-  /** Generator for versions using a timestamp + UUID format */
-  implicit val generateVersion: IO[Version] = IO {
-    val versionString = UUID.randomUUID().toString
-    val timestamp = formatter.format(LocalDateTime.now())
-    Version(s"$timestamp-$versionString")
-  }
-
-  val TimestampAndUuidRegex = """(\d{8}-\d{6}-.*)""".r
-
-  private val formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
-
-  val Unversioned = Version("Unversioned")
 }
 
 //

--- a/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/InMemoryTableVersionsSpec.scala
@@ -10,6 +10,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
   val date = PartitionColumn("date")
   val emptyPartitionedTable = PartitionedTableVersion(Map.empty)
 
+  val version3 = Version.generateVersion.unsafeRunSync()
+
   "The reference implementation for the TableVersions service" should behave like tableVersionsBehaviour {
     InMemoryTableVersions[IO]
   }
@@ -20,8 +22,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
 
   it should "produce the same table when an empty update is applied" in {
     val partitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-02") -> Version("1")
+      Partition(date, "2019-03-01") -> version1,
+      Partition(date, "2019-03-02") -> version2
     )
     val tableVersion = PartitionedTableVersion(partitionVersions)
     InMemoryTableVersions.applyPartitionUpdates(tableVersion)(Nil) shouldBe tableVersion
@@ -29,8 +31,8 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
 
   it should "produce a version with the given partitions when no previous partition versions exist" in {
     val partitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-02") -> Version("1")
+      Partition(date, "2019-03-01") -> version2,
+      Partition(date, "2019-03-02") -> version1
     )
     val partitionUpdates = partitionVersions.map(AddPartitionVersion.tupled).toList
     InMemoryTableVersions.applyPartitionUpdates(emptyPartitionedTable)(partitionUpdates) shouldBe PartitionedTableVersion(
@@ -40,18 +42,18 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
   it should "pick the latest version when an existing partition version is updated" in {
 
     val initialPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-02") -> Version("2"),
-      Partition(date, "2019-03-03") -> Version("1")
+      Partition(date, "2019-03-01") -> version1,
+      Partition(date, "2019-03-02") -> version2,
+      Partition(date, "2019-03-03") -> version1
     )
     val initialTableVersion = PartitionedTableVersion(initialPartitionVersions)
 
-    val partitionUpdates = List(AddPartitionVersion(Partition(date, "2019-03-02"), Version("3")))
+    val partitionUpdates = List(AddPartitionVersion(Partition(date, "2019-03-02"), version3))
 
     val expectedPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-02") -> Version("3"),
-      Partition(date, "2019-03-03") -> Version("1")
+      Partition(date, "2019-03-01") -> version1,
+      Partition(date, "2019-03-02") -> version3,
+      Partition(date, "2019-03-03") -> version1
     )
 
     InMemoryTableVersions.applyPartitionUpdates(initialTableVersion)(partitionUpdates) shouldBe PartitionedTableVersion(
@@ -60,17 +62,17 @@ class InMemoryTableVersionsSpec extends FlatSpec with Matchers with TableVersion
 
   it should "remove an existing partition" in {
     val initialPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-02") -> Version("2"),
-      Partition(date, "2019-03-03") -> Version("1")
+      Partition(date, "2019-03-01") -> version3,
+      Partition(date, "2019-03-02") -> version2,
+      Partition(date, "2019-03-03") -> version1
     )
     val initialTableVersion = PartitionedTableVersion(initialPartitionVersions)
 
     val partitionUpdates = List(RemovePartition(Partition(date, "2019-03-02")))
 
     val expectedPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-03") -> Version("1")
+      Partition(date, "2019-03-01") -> version3,
+      Partition(date, "2019-03-03") -> version1
     )
 
     InMemoryTableVersions.applyPartitionUpdates(initialTableVersion)(partitionUpdates) shouldBe PartitionedTableVersion(

--- a/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
@@ -1,12 +1,14 @@
 package com.gu.tableversions.core
 
 import java.net.URI
+import java.time.LocalDateTime
+import java.util.UUID
 
-import cats.implicits._
 import com.gu.tableversions.core.Partition.PartitionColumn
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import cats.implicits._
 
-class ModelSpec extends FlatSpec with Matchers {
+class ModelSpec extends FlatSpec with Matchers with EitherValues {
 
   val tableLocation = new URI("s3://bucket/data/")
 
@@ -27,21 +29,6 @@ class ModelSpec extends FlatSpec with Matchers {
 
     partition.resolvePath(tableLocation) shouldBe new URI(
       "s3://bucket/data/event_date=2019-01-20/processed_date=2019-01-21/")
-  }
-
-  "Generating versions" should "produce valid labels" in {
-    val version = Version.generateVersion.unsafeRunSync()
-    version.label should fullyMatch regex Version.TimestampAndUuidRegex
-  }
-
-  it should "produce unique labels" in {
-    val versions = (1 to 100).map(_ => Version.generateVersion).toList.sequence.unsafeRunSync()
-    versions.distinct.size shouldBe versions.size
-  }
-
-  "The label format regex" should "match valid labels" in {
-    val validVersionLabel = "20181102-235900-4920d06f-2233-4b4a-9521-8e730eee89c5"
-    validVersionLabel should fullyMatch regex Version.TimestampAndUuidRegex
   }
 
 }

--- a/core/src/test/scala/com/gu/tableversions/core/VersionSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/VersionSpec.scala
@@ -1,0 +1,55 @@
+package com.gu.tableversions.core
+
+import java.time.{Instant, LocalDateTime, ZoneId}
+import java.util.UUID
+
+import cats.implicits._
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class VersionSpec extends FlatSpec with Matchers with EitherValues with PropertyChecks {
+
+  "Generating versions" should "produce valid labels" in {
+    val version = Version.generateVersion.unsafeRunSync()
+    version.label should fullyMatch regex Version.TimestampAndUuidRegex
+  }
+
+  it should "produce unique labels" in {
+    val versions = (1 to 100).map(_ => Version.generateVersion).toList.sequence.unsafeRunSync()
+    versions.distinct.size shouldBe versions.size
+  }
+
+  "The label format regex" should "match valid labels" in {
+    val validVersionLabel = "20181102-235900.123456789-4920d06f-2233-4b4a-9521-8e730eee89c5"
+    validVersionLabel should fullyMatch regex Version.TimestampAndUuidRegex
+  }
+
+  "Version.parse" should "parse a valid version label" in {
+    val validVersionLabel = "20181102-235912.987654321-4920d06f-2233-4b4a-9521-8e730eee89c5"
+
+    val expectedTimestamp = LocalDateTime.of(2018, 11, 2, 23, 59, 12, 987654321).atZone(ZoneId.of("UTC"))
+    val expectedInstant = Instant.from(expectedTimestamp)
+    val expectedUuId = UUID.fromString("4920d06f-2233-4b4a-9521-8e730eee89c5")
+    Version.parse(validVersionLabel) shouldBe Right(Version(expectedInstant, expectedUuId))
+  }
+
+  it should "return an error for invalid version label" in {
+    val error = Version.parse("invalidLabel").left.value
+    error.getMessage shouldBe "invalid version label format invalidLabel"
+  }
+
+  it should "return an error for a label with an invalid UUID part" in {
+    val invalidLabel = "20181102-235900-foobar"
+    val error = Version.parse(invalidLabel).left.value
+    error.getMessage.toLowerCase should include regex s"invalid.*foobar"
+  }
+
+  it should "get the same Version back after rendering and parsing it" in {
+    val genVersion = Gen.delay(Version.generateVersion.unsafeRunSync())
+    forAll(genVersion) { version =>
+      Version.parse(version.label) shouldBe Right(version)
+    }
+  }
+
+}

--- a/metastore/src/main/scala/com/gu/tableversions/metastore/VersionPaths.scala
+++ b/metastore/src/main/scala/com/gu/tableversions/metastore/VersionPaths.scala
@@ -26,10 +26,13 @@ object VersionPaths {
   /**
     * @return a path for a given partition version and base path
     */
-  def pathFor(partitionPath: URI, version: Version): URI = {
-    def normalised(path: String): String = if (path.endsWith("/")) path else path + "/"
-    def versioned(path: String): String = s"$path${version.label}"
-    new URI(versioned(normalised(partitionPath.toString)))
-  }
+  def pathFor(partitionPath: URI, version: Version): URI =
+    if (version == Version.Unversioned)
+      partitionPath
+    else {
+      def normalised(path: String): String = if (path.endsWith("/")) path else path + "/"
+      def versioned(path: String): String = s"$path${version.label}"
+      new URI(versioned(normalised(partitionPath.toString)))
+    }
 
 }

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreObjectSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreObjectSpec.scala
@@ -6,6 +6,9 @@ import com.gu.tableversions.metastore.Metastore.TableOperation._
 import org.scalatest.{FlatSpec, Matchers}
 
 class MetastoreObjectSpec extends FlatSpec with Matchers {
+  val version1 = Version.generateVersion.unsafeRunSync()
+  val version2 = Version.generateVersion.unsafeRunSync()
+  val version3 = Version.generateVersion.unsafeRunSync()
 
   val date = PartitionColumn("date")
 
@@ -13,23 +16,23 @@ class MetastoreObjectSpec extends FlatSpec with Matchers {
     val oldVersion = PartitionedTableVersion(Map.empty)
 
     val newPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-03") -> Version("1")
+      Partition(date, "2019-03-01") -> version3,
+      Partition(date, "2019-03-03") -> version1
     )
     val newVersion = PartitionedTableVersion(newPartitionVersions)
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 
     changes.operations should contain theSameElementsAs List(
-      AddPartition(Partition(date, "2019-03-01"), Version("3")),
-      AddPartition(Partition(date, "2019-03-03"), Version("1"))
+      AddPartition(Partition(date, "2019-03-01"), version3),
+      AddPartition(Partition(date, "2019-03-03"), version1)
     )
   }
 
   it should "produce operations to remove deleted partitions" in {
     val oldPartitionVersions = Map(
-      Partition(date, "2019-03-01") -> Version("3"),
-      Partition(date, "2019-03-03") -> Version("1")
+      Partition(date, "2019-03-01") -> version3,
+      Partition(date, "2019-03-03") -> version1
     )
     val oldVersion = PartitionedTableVersion(oldPartitionVersions)
 
@@ -44,29 +47,29 @@ class MetastoreObjectSpec extends FlatSpec with Matchers {
   }
 
   it should "produce operations to update the versions of existing partitions" in {
-    val oldPartitionVersions = Map(Partition(date, "2019-03-01") -> Version("1"))
+    val oldPartitionVersions = Map(Partition(date, "2019-03-01") -> version1)
     val oldVersion = PartitionedTableVersion(oldPartitionVersions)
 
-    val newPartitionVersions = Map(Partition(date, "2019-03-01") -> Version("2"))
+    val newPartitionVersions = Map(Partition(date, "2019-03-01") -> version2)
     val newVersion = PartitionedTableVersion(newPartitionVersions)
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 
     changes.operations should contain theSameElementsAs List(
-      UpdatePartitionVersion(Partition(date, "2019-03-01"), Version("2")))
+      UpdatePartitionVersion(Partition(date, "2019-03-01"), version2))
   }
 
   it should "produce an operation to update the version of a table for an updated snapshot table version" in {
-    val oldVersion = SnapshotTableVersion(Version("1"))
-    val newVersion = SnapshotTableVersion(Version("2"))
+    val oldVersion = SnapshotTableVersion(version1)
+    val newVersion = SnapshotTableVersion(version2)
 
     val changes = Metastore.computeChanges(oldVersion, newVersion)
 
-    changes.operations should contain theSameElementsAs List(UpdateTableVersion(Version("2")))
+    changes.operations should contain theSameElementsAs List(UpdateTableVersion(version2))
   }
 
   it should "produce no change for a snapshot table with the same version" in {
-    val version = SnapshotTableVersion(Version("1"))
+    val version = SnapshotTableVersion(version1)
 
     val changes = Metastore.computeChanges(version, version)
 

--- a/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreSpec.scala
+++ b/metastore/src/test/scala/com/gu/tableversions/metastore/MetastoreSpec.scala
@@ -48,10 +48,8 @@ trait MetastoreSpec {
         scenario.unsafeRunSync()
 
       initialVersion shouldBe SnapshotTableVersion(Version.Unversioned)
-      firstUpdatedVersion shouldBe
-        SnapshotTableVersion(version1)
-      secondUpdatedVersion shouldBe
-        SnapshotTableVersion(version2)
+      firstUpdatedVersion shouldBe SnapshotTableVersion(version1)
+      secondUpdatedVersion shouldBe SnapshotTableVersion(version2)
       revertedVersion shouldEqual firstUpdatedVersion
     }
 

--- a/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
@@ -35,7 +35,7 @@ class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite 
   // Tests specific to the Spark/Hive implementation
   //
 
-  val validVersionLabel = "20181102-235900-4920d06f-2233-4b4a-9521-8e730eee89c5"
+  val validVersion = Version.generateVersion.unsafeRunSync()
 
   "Parsing a valid partition string" should "produce the expected values" in {
     val testData = Table(
@@ -87,11 +87,10 @@ class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite 
   }
 
   "Parsing the version from versioned paths" should "produce the version number" in {
-    parseVersion(new URI(s"file:/tmp/7bbc577c-471d-4ece-8462/table/date=2019-01-21/2019/$validVersionLabel")) shouldBe Version(
-      validVersionLabel)
-    parseVersion(new URI(s"s3://bucket/pageview/date=2019-01-21/$validVersionLabel")) shouldBe Version(
-      validVersionLabel)
-    parseVersion(new URI(s"s3://bucket/identity/$validVersionLabel")) shouldBe Version(validVersionLabel)
+    parseVersion(new URI(s"file:/tmp/7bbc577c-471d-4ece-8462/table/date=2019-01-21/2019/${validVersion.label}")) shouldBe validVersion
+
+    parseVersion(new URI(s"s3://bucket/pageview/date=2019-01-21/${validVersion.label}")) shouldBe validVersion
+    parseVersion(new URI(s"s3://bucket/identity/${validVersion.label}")) shouldBe validVersion
   }
 
   "Parsing the version from unversioned paths" should "produce version 0" in {
@@ -116,7 +115,7 @@ class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite 
   }
 
   it should "return strip off the version part of the path" in {
-    versionedToBasePath(new URI(s"hdfs://bucket/identity/$validVersionLabel")) shouldBe new URI(
+    versionedToBasePath(new URI(s"hdfs://bucket/identity/${validVersion.label}")) shouldBe new URI(
       "hdfs://bucket/identity")
   }
 


### PR DESCRIPTION
This is a refactoring to specify more strictly the definition of a `Version`. Instead of just a `String`, it can now only be created with a timestamp and UUID. Also, the parsing and rendering of string representations of versions is moved to the `Version` type.
