### PR TITLE
Add assembly settings

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")


### PR DESCRIPTION
This adds the sbt-assembly plugin and settings to build fat jar files for the various submodules.

This PR also renames the modules to provide sane names for the generated jar files.