### PR TITLE
PartitionColumn fix for kryo

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -30,7 +30,7 @@ object Partition {
   /** Convenience constructor for multiple partitions. */
   def apply(first: ColumnValue, rest: ColumnValue*): Partition = Partition(NonEmptyList(first, rest.toList))
 
-  case class PartitionColumn(name: String) extends AnyVal
+  case class PartitionColumn(name: String)
 
   case class ColumnValue(column: PartitionColumn, value: String)
 

--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -30,6 +30,9 @@ object Partition {
   /** Convenience constructor for multiple partitions. */
   def apply(first: ColumnValue, rest: ColumnValue*): Partition = Partition(NonEmptyList(first, rest.toList))
 
+  /**
+    * Note: do not add `extends AnyVal`. It breaks kryo serialisation.
+    */
   case class PartitionColumn(name: String)
 
   case class ColumnValue(column: PartitionColumn, value: String)

--- a/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/ModelSpec.scala
@@ -1,12 +1,9 @@
 package com.gu.tableversions.core
 
 import java.net.URI
-import java.time.LocalDateTime
-import java.util.UUID
 
 import com.gu.tableversions.core.Partition.PartitionColumn
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
-import cats.implicits._
 
 class ModelSpec extends FlatSpec with Matchers with EitherValues {
 

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -32,14 +32,12 @@ object VersionedDataset {
       * @return a tuple containing the updated table version information, and a list of the changes that were applied
       *         to the metastore.
       */
-    def versionedInsertInto(table: TableDefinition, userId: UserId, message: String)(
-        implicit tableVersions: TableVersions[IO],
-        metastore: Metastore[IO]): (TableVersion, TableChanges) =
+    def versionedInsertInto(table: TableDefinition, userId: UserId, message: String): (TableVersion, TableChanges) =
       versionedInsertDatasetIntoTable(delegate, table, userId, message).unsafeRunSync()
 
   }
 
-  private def versionedInsertDatasetIntoTable[T](
+  def versionedInsertDatasetIntoTable[T](
       dataset: Dataset[T],
       table: TableDefinition,
       userId: UserId,

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -37,11 +37,11 @@ object VersionedDataset {
 
   }
 
-  def versionedInsertDatasetIntoTable[T](
-      dataset: Dataset[T],
-      table: TableDefinition,
-      userId: UserId,
-      message: String)(
+  /**
+    * Keep default (public) scope. It was `private` before and failed at Runtime (yet compiled...).
+    * Have not tried with other scopes.
+    */
+  def versionedInsertDatasetIntoTable[T](dataset: Dataset[T], table: TableDefinition, userId: UserId, message: String)(
       implicit tableVersions: TableVersions[IO],
       metastore: Metastore[IO],
       generateVersion: IO[Version]): IO[(TableVersion, TableChanges)] = {

--- a/spark/src/test/scala/com/gu/tableversions/spark/KryoSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/KryoSpec.scala
@@ -1,0 +1,34 @@
+package com.gu.tableversions.spark
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.Output
+import com.gu.tableversions.core.Partition.PartitionColumn
+import org.scalatest.{FlatSpec, Matchers}
+
+class KryoSpec extends FlatSpec with Matchers {
+
+  /**
+    * Not a very conclusive test.
+    *
+    * This test is trying to prove that PartitionColumn is kryo-serialisable.
+    * There is an issue when the class in used within ophan-data-lake such that kryo fails with:
+    *
+    * java.lang.ClassCastException: com.gu.tableversions.core.Partition$PartitionColumn cannot be cast to java.lang.String
+    *
+    * The problem is (or seems to be) with the resulting class signature
+    *
+    * final case class PartitionColumn(val name : scala.Predef.String) extends scala.AnyVal with scala.Product with scala.Serializable
+    *
+    * => scala.AnyVal is the problem
+    *
+    * Sadly, this test below passes regardless from within table-versions
+    * Once the first ophan-data-lake's versioned job happen, this test will be (could be) moved here.
+    * Or alternatively, refrain from using AnyVal for spark-bound case classes.
+    *
+    */
+  "kryo" should "not throw an exception upon serialising PartitionColumn" in {
+    val kryo = new Kryo
+
+    kryo.writeObject(new Output(1024, -1), PartitionColumn("col"))
+  }
+}


### PR DESCRIPTION
PartitionColumn serialisation fails with

```
java.lang.ClassCastException: com.gu.tableversions.core.Partition$PartitionColumn cannot be cast to java.lang.String
```