### PR TITLE
Group all versioning concerns under a `VersionContext` umbrella

### DIFF
--- a/examples/src/main/scala/com/gu/tableversions/examples/TableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/TableLoader.scala
@@ -2,10 +2,8 @@ package com.gu.tableversions.examples
 
 import java.time.Instant
 
-import cats.effect.IO
 import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
-import com.gu.tableversions.core.{TableDefinition, TableVersions, Version}
-import com.gu.tableversions.metastore.Metastore
+import com.gu.tableversions.core.{TableDefinition, TableVersions}
 import com.gu.tableversions.spark.{SparkSupport, VersionContext}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{Dataset, SparkSession}

--- a/examples/src/main/scala/com/gu/tableversions/examples/TableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/TableLoader.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core.{TableDefinition, TableVersions, Version}
 import com.gu.tableversions.metastore.Metastore
-import com.gu.tableversions.spark.VersionedDataset
+import com.gu.tableversions.spark.VersionContext
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{Dataset, SparkSession}
 
@@ -15,14 +15,16 @@ import scala.reflect.runtime.universe.TypeTag
 /**
   * Example code for loading data into versioned tables and updating the versions of such tables.
   */
-class TableLoader[T <: Product: TypeTag](table: TableDefinition, createTableDdl: String, isSnapshot: Boolean)(
-    implicit tableVersions: TableVersions[IO],
-    metastore: Metastore[IO],
-    generateVersion: IO[Version],
-    spark: SparkSession)
+class TableLoader[T <: Product: TypeTag](
+    versionContext: VersionContext,
+    table: TableDefinition,
+    createTableDdl: String,
+    isSnapshot: Boolean)(implicit spark: SparkSession)
     extends LazyLogging {
 
   import spark.implicits._
+  import versionContext._
+  import versionContext.implicits._
 
   def initTable(userId: UserId, message: UpdateMessage): Unit = {
     // Create table in underlying metastore
@@ -36,8 +38,6 @@ class TableLoader[T <: Product: TypeTag](table: TableDefinition, createTableDdl:
     spark.table(table.name.fullyQualifiedName).as[T]
 
   def insert(dataset: Dataset[T], userId: UserId, message: String): Unit = {
-    import VersionedDataset._
-
     val (latestVersion, metastoreChanges) = dataset.versionedInsertInto(table, userId, message)
 
     logger.info(s"Updated table $table, new version details:\n$latestVersion")

--- a/examples/src/main/scala/com/gu/tableversions/examples/TableLoader.scala
+++ b/examples/src/main/scala/com/gu/tableversions/examples/TableLoader.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core.{TableDefinition, TableVersions, Version}
 import com.gu.tableversions.metastore.Metastore
-import com.gu.tableversions.spark.VersionContext
+import com.gu.tableversions.spark.{SparkSupport, VersionContext}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{Dataset, SparkSession}
 
@@ -24,7 +24,8 @@ class TableLoader[T <: Product: TypeTag](
 
   import spark.implicits._
   import versionContext._
-  import versionContext.implicits._
+  val ss = SparkSupport(versionContext)
+  import ss.syntax._
 
   def initTable(userId: UserId, message: UpdateMessage): Unit = {
     // Create table in underlying metastore

--- a/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
@@ -4,13 +4,11 @@ import java.net.URI
 import java.nio.file.Paths
 import java.sql.{Date, Timestamp}
 
-import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions._
 import com.gu.tableversions.core._
+import com.gu.tableversions.spark.SparkHiveSuite
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
-import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite, VersionContext}
-import org.apache.spark.sql.SparkSession
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -170,14 +168,4 @@ object DatePartitionedTableLoaderSpec {
 
   }
 
-}
-
-object TestVersionContext {
-
-  def default(implicit spark: SparkSession): IO[VersionContext] =
-    for {
-      tableVersions <- InMemoryTableVersions[IO]
-      metastore = new SparkHiveMetastore[IO]()
-      versionGenerator = Version.generateVersion
-    } yield VersionContext(tableVersions, metastore, versionGenerator)
 }

--- a/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
@@ -3,13 +3,11 @@ package com.gu.tableversions.examples
 import java.nio.file.Path
 import java.sql.{Date, Timestamp}
 
-import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore
+import com.gu.tableversions.spark.SparkHiveSuite
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
-import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite, VersionContext}
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -25,10 +23,9 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
   "Writing multiple versions of a dataset with multiple partition columns" should "produce distinct partition versions" in {
 
     import spark.implicits._
-    val tableVersions: TableVersions[IO] = InMemoryTableVersions[IO].unsafeRunSync()
-    val metastore: Metastore[IO] = new SparkHiveMetastore[IO]()
-    val versionGenerator: IO[Version] = Version.generateVersion
-    val versionContext = VersionContext(tableVersions, metastore, versionGenerator)
+
+    val versionContext = TestVersionContext.default.unsafeRunSync()
+    import versionContext.tableVersions
 
     val table = TableDefinition(
       TableName(schema, "ad_impressions"),

--- a/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
@@ -3,12 +3,10 @@ package com.gu.tableversions.examples
 import java.net.URI
 import java.nio.file.Paths
 
-import cats.effect.IO
 import com.gu.tableversions.core.TableVersions.{UpdateMessage, UserId}
 import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore
+import com.gu.tableversions.spark.SparkHiveSuite
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
-import com.gu.tableversions.spark.{SparkHiveMetastore, SparkHiveSuite, VersionContext}
 import org.scalatest.{FlatSpec, Matchers}
 
 /**
@@ -35,10 +33,8 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
   "Writing multiple versions of a snapshot dataset" should "produce distinct versions" in {
     import spark.implicits._
 
-    val tableVersions: TableVersions[IO] = InMemoryTableVersions[IO].unsafeRunSync()
-    val metastore: Metastore[IO] = new SparkHiveMetastore[IO]()
-    val versionGenerator: IO[Version] = Version.generateVersion
-    val versionContext = VersionContext(tableVersions, metastore, versionGenerator)
+    val versionContext = TestVersionContext.default.unsafeRunSync()
+    import versionContext.tableVersions
 
     val userId = UserId("test user")
 

--- a/examples/src/test/scala/com/gu/tableversions/examples/TestVersionContext.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/TestVersionContext.scala
@@ -1,0 +1,16 @@
+package com.gu.tableversions.examples
+
+import cats.effect.IO
+import com.gu.tableversions.core.{InMemoryTableVersions, Version}
+import com.gu.tableversions.spark.{SparkHiveMetastore, VersionContext}
+import org.apache.spark.sql.SparkSession
+
+object TestVersionContext {
+
+  def default(implicit spark: SparkSession): IO[VersionContext] =
+    for {
+      tableVersions <- InMemoryTableVersions[IO]
+      metastore = new SparkHiveMetastore[IO]()
+      versionGenerator = Version.generateVersion
+    } yield VersionContext(tableVersions, metastore, versionGenerator)
+}

--- a/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
@@ -46,12 +46,12 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
       Partition(PartitionColumn("date"), "2019-01-16"),
       Partition(PartitionColumn("date"), "2019-01-18")
     )
-    VersionContext.partitionValues(partitionedDataset, schema) should contain theSameElementsAs expectedPartitions
+    SparkSupport.partitionValues(partitionedDataset, schema) should contain theSameElementsAs expectedPartitions
   }
 
   it should "return no partitions for an empty dataset with a partitioned schema" in {
     val schema = PartitionSchema(List(PartitionColumn("date")))
-    VersionContext.partitionValues(spark.emptyDataset[Event], schema) shouldBe empty
+    SparkSupport.partitionValues(spark.emptyDataset[Event], schema) shouldBe empty
   }
 
   "Writing a dataset with multiple partitions" should "store the data for each partition in a versioned folder for the partition" in {
@@ -77,7 +77,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
       Partition(PartitionColumn("date"), "2019-01-18") -> version1
     )
 
-    VersionContext.writeVersionedPartitions(eventsGroup1.toDS(), table, partitionPathsV1)
+    SparkSupport.writeVersionedPartitions(eventsGroup1.toDS(), table, partitionPathsV1)
 
     readDataset[Event](new URI(versionedPath))
       .collect() should contain theSameElementsAs eventsGroup1
@@ -96,7 +96,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
       Partition(PartitionColumn("date"), "2019-01-18") -> version2
     )
 
-    VersionContext.writeVersionedPartitions(eventsGroup2.toDS(), table, partitionPathsV2)
+    SparkSupport.writeVersionedPartitions(eventsGroup2.toDS(), table, partitionPathsV2)
 
     readDataset[Event](new URI(versionedPath))
       .collect() should contain theSameElementsAs eventsGroup2
@@ -123,7 +123,8 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     }
 
     import versionContext._
-    import versionContext.implicits._
+    val ss = SparkSupport(versionContext)
+    import ss.syntax._
 
     val users = List(
       User("101", "Alice"),
@@ -177,7 +178,8 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     }
 
     import versionContext._
-    import versionContext.implicits._
+    val ss = SparkSupport(versionContext)
+    import ss.syntax._
 
     val events = List(
       Event("101", "A", Date.valueOf("2019-01-15")),
@@ -234,7 +236,8 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     }
 
     import versionContext._
-    import versionContext.implicits._
+    val ss = SparkSupport(versionContext)
+    import ss.syntax._
 
     val eventsDay1 = List(
       Event("101", "A", Date.valueOf("2019-01-15")),

--- a/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
@@ -11,15 +11,15 @@ import com.gu.tableversions.core._
 import com.gu.tableversions.metastore.Metastore
 import com.gu.tableversions.metastore.Metastore.TableChanges
 import com.gu.tableversions.metastore.Metastore.TableOperation.{AddPartition, UpdateTableVersion}
-import com.gu.tableversions.spark.VersionedDataset._
-import com.gu.tableversions.spark.VersionedDatasetSpec.{Event, User}
+import com.gu.tableversions.spark.VersionContext._
+import com.gu.tableversions.spark.VersionContextSpec.{Event, User}
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
 import org.apache.spark.sql.Dataset
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.reflect.runtime.universe.TypeTag
 
-class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
+class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
 
   override def customConfig = VersionedFileSystem.sparkConfig("file", tableDir.toUri)
 
@@ -28,7 +28,7 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
   // Stub version generator that returns the same version on every invocation
   lazy val version1 = Version.generateVersion.unsafeRunSync()
   lazy val version2 = Version.generateVersion.unsafeRunSync()
-  implicit val generateVersion: IO[Version] = IO.pure(version1)
+  val generateVersion: IO[Version] = IO.pure(version1)
 
   it should "return all partitions for a dataset with a single partition column" in {
 
@@ -46,12 +46,12 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
       Partition(PartitionColumn("date"), "2019-01-16"),
       Partition(PartitionColumn("date"), "2019-01-18")
     )
-    VersionedDataset.partitionValues(partitionedDataset, schema) should contain theSameElementsAs expectedPartitions
+    VersionContext.partitionValues(partitionedDataset, schema) should contain theSameElementsAs expectedPartitions
   }
 
   it should "return no partitions for an empty dataset with a partitioned schema" in {
     val schema = PartitionSchema(List(PartitionColumn("date")))
-    VersionedDataset.partitionValues(spark.emptyDataset[Event], schema) shouldBe empty
+    VersionContext.partitionValues(spark.emptyDataset[Event], schema) shouldBe empty
   }
 
   "Writing a dataset with multiple partitions" should "store the data for each partition in a versioned folder for the partition" in {
@@ -77,7 +77,7 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
       Partition(PartitionColumn("date"), "2019-01-18") -> version1
     )
 
-    VersionedDataset.writeVersionedPartitions(eventsGroup1.toDS(), table, partitionPathsV1)
+    VersionContext.writeVersionedPartitions(eventsGroup1.toDS(), table, partitionPathsV1)
 
     readDataset[Event](new URI(versionedPath))
       .collect() should contain theSameElementsAs eventsGroup1
@@ -96,7 +96,7 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
       Partition(PartitionColumn("date"), "2019-01-18") -> version2
     )
 
-    VersionedDataset.writeVersionedPartitions(eventsGroup2.toDS(), table, partitionPathsV2)
+    VersionContext.writeVersionedPartitions(eventsGroup2.toDS(), table, partitionPathsV2)
 
     readDataset[Event](new URI(versionedPath))
       .collect() should contain theSameElementsAs eventsGroup2
@@ -105,19 +105,25 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
   "Inserting a snapshot dataset" should "write the data to the versioned location and commit the new version" in {
     val usersTable = TableDefinition(TableName(schema, "users"), tableUri, PartitionSchema.snapshot, FileFormat.Orc)
 
-    // Stub metastore
     val initialTableVersion = SnapshotTableVersion(Version.Unversioned)
-
     val stubbedChanges = TableChanges(List(UpdateTableVersion(version1)))
-    implicit val stubMetastore: Metastore[IO] = new StubMetastore(
-      currentVersion = initialTableVersion,
-      computedChanges = stubbedChanges
-    )
 
-    implicit val tableVersions: TableVersions[IO] = (for {
-      t <- InMemoryTableVersions[IO]
-      _ <- t.init(usersTable.name, isSnapshot = true, UserId("test"), UpdateMessage("init"), Instant.now())
-    } yield t).unsafeRunSync()
+    val versionContext = {
+      val stubMetastore: Metastore[IO] = new StubMetastore(
+        currentVersion = initialTableVersion,
+        computedChanges = stubbedChanges
+      )
+
+      val tableVersions: TableVersions[IO] = (for {
+        t <- InMemoryTableVersions[IO]
+        _ <- t.init(usersTable.name, isSnapshot = true, UserId("test"), UpdateMessage("init"), Instant.now())
+      } yield t).unsafeRunSync()
+
+      VersionContext(tableVersions, stubMetastore, generateVersion)
+    }
+
+    import versionContext._
+    import versionContext.implicits._
 
     val users = List(
       User("101", "Alice"),
@@ -156,16 +162,22 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
     val initialTableVersion = PartitionedTableVersion(partitionVersions = Map.empty)
     val stubbedChanges = TableChanges(initialTableVersion.partitionVersions.map(AddPartition.tupled).toList)
 
-    // Stub metastore
-    implicit val stubMetastore: Metastore[IO] = new StubMetastore(
-      currentVersion = initialTableVersion,
-      computedChanges = stubbedChanges
-    )
+    val versionContext = {
+      val stubMetastore: Metastore[IO] = new StubMetastore(
+        currentVersion = initialTableVersion,
+        computedChanges = stubbedChanges
+      )
 
-    implicit val tableVersions: TableVersions[IO] = (for {
-      t <- InMemoryTableVersions[IO]
-      _ <- t.init(eventsTable.name, isSnapshot = false, UserId("test"), UpdateMessage("init"), Instant.now())
-    } yield t).unsafeRunSync()
+      val tableVersions: TableVersions[IO] = (for {
+        t <- InMemoryTableVersions[IO]
+        _ <- t.init(eventsTable.name, isSnapshot = false, UserId("test"), UpdateMessage("init"), Instant.now())
+      } yield t).unsafeRunSync()
+
+      VersionContext(tableVersions, stubMetastore, generateVersion)
+    }
+
+    import versionContext._
+    import versionContext.implicits._
 
     val events = List(
       Event("101", "A", Date.valueOf("2019-01-15")),
@@ -207,16 +219,22 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
     val initialTableVersion = PartitionedTableVersion(partitionVersions = Map.empty)
     val stubbedChanges = TableChanges(initialTableVersion.partitionVersions.map(AddPartition.tupled).toList)
 
-    // Stub metastore
-    implicit val stubMetastore: Metastore[IO] = new StubMetastore(
-      currentVersion = initialTableVersion,
-      computedChanges = stubbedChanges
-    )
+    val versionContext = {
+      val stubMetastore: Metastore[IO] = new StubMetastore(
+        currentVersion = initialTableVersion,
+        computedChanges = stubbedChanges
+      )
 
-    implicit val tableVersions: TableVersions[IO] = (for {
-      t <- InMemoryTableVersions[IO]
-      _ <- t.init(eventsTable.name, isSnapshot = false, UserId("test"), UpdateMessage("init"), Instant.now())
-    } yield t).unsafeRunSync()
+      val tableVersions: TableVersions[IO] = (for {
+        t <- InMemoryTableVersions[IO]
+        _ <- t.init(eventsTable.name, isSnapshot = false, UserId("test"), UpdateMessage("init"), Instant.now())
+      } yield t).unsafeRunSync()
+
+      VersionContext(tableVersions, stubMetastore, generateVersion)
+    }
+
+    import versionContext._
+    import versionContext.implicits._
 
     val eventsDay1 = List(
       Event("101", "A", Date.valueOf("2019-01-15")),
@@ -278,7 +296,7 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
 
 }
 
-object VersionedDatasetSpec {
+object VersionContextSpec {
 
   case class User(id: String, name: String)
 


### PR DESCRIPTION
Having a play with application wiring and dependency passing -- see what you think.