### PR TITLE
Add support for arbitrary file formats for tables

### DIFF
--- a/core/src/main/scala/com/gu/tableversions/core/model.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/model.scala
@@ -90,7 +90,7 @@ final case class TableName(schema: String, name: String) {
   def fullyQualifiedName: String = s"$schema.$name"
 }
 
-final case class TableDefinition(name: TableName, location: URI, partitionSchema: PartitionSchema) {
+final case class TableDefinition(name: TableName, location: URI, partitionSchema: PartitionSchema, format: FileFormat) {
   def isSnapshot: Boolean = partitionSchema == PartitionSchema.snapshot
 }
 
@@ -100,3 +100,10 @@ final case class TableDefinition(name: TableName, location: URI, partitionSchema
 sealed trait TableVersion
 final case class PartitionedTableVersion(partitionVersions: Map[Partition, Version]) extends TableVersion
 final case class SnapshotTableVersion(version: Version) extends TableVersion
+
+case class FileFormat(name: String) extends AnyVal
+
+object FileFormat {
+  val Parquet = FileFormat("parquet")
+  val Orc = FileFormat("orc")
+}

--- a/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/DatePartitionedTableLoaderSpec.scala
@@ -26,7 +26,8 @@ class DatePartitionedTableLoaderSpec extends FlatSpec with Matchers with SparkHi
   val table = TableDefinition(
     TableName(schema, "pageview"),
     tableUri,
-    PartitionSchema(List(PartitionColumn("date")))
+    PartitionSchema(List(PartitionColumn("date"))),
+    FileFormat.Parquet
   )
 
   val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (

--- a/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/MultiPartitionTableLoaderSpec.scala
@@ -32,7 +32,8 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
     val table = TableDefinition(
       TableName(schema, "ad_impressions"),
       tableUri,
-      PartitionSchema(List(PartitionColumn("impression_date"), PartitionColumn("processed_date")))
+      PartitionSchema(List(PartitionColumn("impression_date"), PartitionColumn("processed_date"))),
+      FileFormat.Orc
     )
 
     val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (
@@ -41,7 +42,7 @@ class MultiPartitionTableLoaderSpec extends FlatSpec with Matchers with SparkHiv
                  |  `timestamp` timestamp
                  |)
                  |PARTITIONED BY (`impression_date` date, `processed_date` date)
-                 |STORED AS parquet
+                 |STORED AS orc
                  |LOCATION '${table.location}'
     """.stripMargin
 

--- a/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
@@ -21,7 +21,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
 
   import SnapshotTableLoaderSpec._
 
-  val table = TableDefinition(TableName(schema, "users"), tableUri, PartitionSchema.snapshot)
+  val table = TableDefinition(TableName(schema, "users"), tableUri, PartitionSchema.snapshot, FileFormat.Parquet)
 
   val ddl = s"""CREATE EXTERNAL TABLE IF NOT EXISTS ${table.name.fullyQualifiedName} (
                |  `id` string,

--- a/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
+++ b/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
@@ -53,13 +53,16 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
 
     val snapshotTable = {
       val tableName = "test_snapshot_" + dedupSuffix
-      TableDefinition(TableName(schema, tableName), tableLocation, PartitionSchema.snapshot)
+      TableDefinition(TableName(schema, tableName), tableLocation, PartitionSchema.snapshot, FileFormat.Parquet)
     }
 
     val partitionedTable = {
       val tableName = "test_partitioned_" + dedupSuffix
 
-      TableDefinition(TableName(schema, tableName), tableLocation, PartitionSchema(List(PartitionColumn("date"))))
+      TableDefinition(TableName(schema, tableName),
+                      tableLocation,
+                      PartitionSchema(List(PartitionColumn("date"))),
+                      FileFormat.Parquet)
     }
 
     "A metastore implementation" should behave like metastoreWithSnapshotSupport(IO {

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionedDataset.scala
@@ -126,9 +126,10 @@ object VersionedDataset {
 
     val partitions = table.partitionSchema.columns.map(_.name)
 
-    dataset.write
+    dataset.toDF.write
       .partitionBy(partitions: _*)
       .mode(SaveMode.Append)
-      .parquet(VersionedFileSystem.scheme + "://" + table.location.getPath) // TODO: Take in format parameter. Or a dataset writer?
+      .format(table.format.name)
+      .save(VersionedFileSystem.scheme + "://" + table.location.getPath)
   }
 }

--- a/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
@@ -11,11 +11,12 @@ import org.scalatest.{FlatSpec, Matchers}
 class SparkHiveMetastoreSpec extends FlatSpec with Matchers with SparkHiveSuite with MetastoreSpec with PropertyChecks {
 
   val snapshotTable =
-    TableDefinition(TableName(schema, "users"), resolveTablePath("users"), PartitionSchema.snapshot)
+    TableDefinition(TableName(schema, "users"), resolveTablePath("users"), PartitionSchema.snapshot, FileFormat.Parquet)
 
   val partitionedTable = TableDefinition(TableName(schema, "clicks"),
                                          resolveTablePath("clicks"),
-                                         PartitionSchema(List(PartitionColumn("date"))))
+                                         PartitionSchema(List(PartitionColumn("date"))),
+                                         FileFormat.Parquet)
   //
   // Common specs
   //

--- a/spark/src/test/scala/com/gu/tableversions/spark/VersionedDatasetSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/VersionedDatasetSpec.scala
@@ -59,7 +59,10 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
     import spark.implicits._
 
     val versionedPath = tableUri.resolve(s"table").toString.replace("file:", "versioned://")
-    val table = TableDefinition(TableName("dev", "test"), tableUri, PartitionSchema(List(PartitionColumn("date"))))
+    val table = TableDefinition(TableName("dev", "test"),
+                                tableUri,
+                                PartitionSchema(List(PartitionColumn("date"))),
+                                FileFormat.Parquet)
 
     val eventsGroup1 = List(
       Event("101", "A", Date.valueOf("2019-01-15")),
@@ -100,7 +103,7 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
   }
 
   "Inserting a snapshot dataset" should "write the data to the versioned location and commit the new version" in {
-    val usersTable = TableDefinition(TableName(schema, "users"), tableUri, PartitionSchema.snapshot)
+    val usersTable = TableDefinition(TableName(schema, "users"), tableUri, PartitionSchema.snapshot, FileFormat.Orc)
 
     // Stub metastore
     val initialTableVersion = SnapshotTableVersion(Version.Unversioned)
@@ -145,7 +148,10 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
 
   "Inserting multiple records into the same partition" should "write the correct data to the filesystem" in {
     val eventsTable =
-      TableDefinition(TableName(schema, "events"), tableUri, PartitionSchema(List(PartitionColumn("date"))))
+      TableDefinition(TableName(schema, "events"),
+                      tableUri,
+                      PartitionSchema(List(PartitionColumn("date"))),
+                      FileFormat.Parquet)
 
     val initialTableVersion = PartitionedTableVersion(partitionVersions = Map.empty)
     val stubbedChanges = TableChanges(initialTableVersion.partitionVersions.map(AddPartition.tupled).toList)
@@ -193,7 +199,10 @@ class VersionedDatasetSpec extends FlatSpec with Matchers with SparkHiveSuite {
 
   "Inserting a partitioned dataset" should "write the data to the versioned partitions and commit the new versions" in {
     val eventsTable =
-      TableDefinition(TableName(schema, "events"), tableUri, PartitionSchema(List(PartitionColumn("date"))))
+      TableDefinition(TableName(schema, "events"),
+                      tableUri,
+                      PartitionSchema(List(PartitionColumn("date"))),
+                      FileFormat.Parquet)
 
     val initialTableVersion = PartitionedTableVersion(partitionVersions = Map.empty)
     val stubbedChanges = TableChanges(initialTableVersion.partitionVersions.map(AddPartition.tupled).toList)


### PR DESCRIPTION
This adds a 'file format' field to table definitions, so that tables can be written in any format that Spark supports.