### PR TITLE
add format information to glue metastore

### DIFF
--- a/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
+++ b/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
@@ -159,14 +159,14 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with MetastoreSpec {
         getPartitionsReq = new GetPartitionsRequest()
           .withTableName(partitionedTable.name.name)
           .withDatabaseName(partitionedTable.name.schema)
-        expectedVersionBeforeUpdate <- Version.generateVersion
-        expectedVersionAfterUpdate <- Version.generateVersion
-        _ <- metastore.addPartition(partitionedTable.name, partition, expectedVersionBeforeUpdate)
+        version1 <- Version.generateVersion
+        version2 <- Version.generateVersion
+        _ <- metastore.addPartition(partitionedTable.name, partition, version1)
         partitionsBeforeUpdate = glue.getPartitions(getPartitionsReq).getPartitions.asScala
-        _ <- metastore.updatePartitionVersion(partitionedTable.name, partition, expectedVersionAfterUpdate)
+        _ <- metastore.updatePartitionVersion(partitionedTable.name, partition, version2)
         partitionsAfterUpdate = glue.getPartitions(getPartitionsReq).getPartitions.asScala
 
-      } yield (partitionsBeforeUpdate, partitionsAfterUpdate, expectedVersionBeforeUpdate, expectedVersionAfterUpdate)
+      } yield (partitionsBeforeUpdate, partitionsAfterUpdate, version1, version2)
 
       val (partitionsBeforeUpdate, partitionsAfterUpdate, expectedVersionBeforeUpdate, expectedVersionAfterUpdate) =
         scenario.guarantee(deleteTable(partitionedTable.name)).unsafeRunSync()

--- a/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
+++ b/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
@@ -6,12 +6,21 @@ import cats.effect.IO
 import cats.implicits._
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.glue.model._
+import com.amazonaws.services.glue.model.{
+  Column,
+  CreateTableRequest,
+  DeleteTableRequest,
+  GetPartitionsRequest,
+  GetTableRequest,
+  SerDeInfo,
+  StorageDescriptor,
+  TableInput
+}
 import com.amazonaws.services.glue.{AWSGlue, AWSGlueClient}
 import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core._
 import com.gu.tableversions.metastore.MetastoreSpec
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{Assertion, BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.util.{Properties, Random}
 
@@ -36,6 +45,7 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
   }
 
   def runWithVariables(schema: String, awsRegion: String, awsProfile: Option[String]): Unit = {
+
     val providers: List[AWSCredentialsProvider] = {
 
       List(new EnvironmentVariableCredentialsProvider, new SystemPropertiesCredentialsProvider) ++
@@ -48,6 +58,9 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
     val glue: AWSGlue = AWSGlueClient.builder().withCredentials(credentials).withRegion(awsRegion).build()
 
     val tableLocation = new URI("/table-versions-test/")
+    val testInputFormat = "org.fake.InputFormat"
+    val testOutPutFormat = "org.fake.OutputFormat"
+    val testSerialisationLib = "org.fake.serde.FakeSerde"
 
     val dedupSuffix = Random.alphanumeric.take(8).mkString("")
 
@@ -74,12 +87,17 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
     }, initTable(partitionedTable), partitionedTable.name, deleteTable(partitionedTable.name))
 
     def initTable(table: TableDefinition): IO[Unit] = {
+      val serdeInfo =
+        new SerDeInfo().withSerializationLibrary(testSerialisationLib)
       val storageDescription = new StorageDescriptor()
         .withLocation(table.location.toString)
         .withColumns(
           new Column().withName("id").withType("String"),
           new Column().withName("field1").withType("String")
         )
+        .withSerdeInfo(serdeInfo)
+        .withInputFormat(testInputFormat)
+        .withOutputFormat(testOutPutFormat)
 
       val input = {
         val unpartitionedInput = new TableInput()
@@ -104,6 +122,90 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
       IO {
         glue.deleteTable(deleteRequest)
       }.void
+    }
+
+    "creating a partition" should "set format parameters" in {
+      import scala.collection.JavaConverters._
+
+      val scenario = for {
+        _ <- initTable(partitionedTable)
+        metastore = new GlueMetastore[IO](glue)
+        dateCol = PartitionColumn("date")
+        partition = Partition(dateCol, "2019-01-01")
+        version <- Version.generateVersion
+        _ <- metastore.addPartition(partitionedTable.name, partition, version)
+        req = new GetPartitionsRequest()
+          .withTableName(partitionedTable.name.name)
+          .withDatabaseName(partitionedTable.name.schema)
+      } yield (glue.getPartitions(req).getPartitions.asScala, version)
+
+      val (partitions, version) = scenario.guarantee(deleteTable(partitionedTable.name)).unsafeRunSync()
+
+      partitions should have size 1
+      partitions.head.getStorageDescriptor.getLocation shouldBe s"${tableLocation}date=2019-01-01/${version.label}"
+      partitions.head.getStorageDescriptor.getInputFormat shouldBe testInputFormat
+      partitions.head.getStorageDescriptor.getOutputFormat shouldBe testOutPutFormat
+      partitions.head.getStorageDescriptor.getSerdeInfo.getSerializationLibrary shouldBe testSerialisationLib
+    }
+
+    "updating a partition version" should "preserve format parameters" in {
+      import scala.collection.JavaConverters._
+
+      val scenario = for {
+        _ <- initTable(partitionedTable)
+        metastore = new GlueMetastore[IO](glue)
+        dateCol = PartitionColumn("date")
+        partition = Partition(dateCol, "2019-01-01")
+        getPartitionsReq = new GetPartitionsRequest()
+          .withTableName(partitionedTable.name.name)
+          .withDatabaseName(partitionedTable.name.schema)
+        expectedVersionBeforeUpdate <- Version.generateVersion
+        expectedVersionAfterUpdate <- Version.generateVersion
+        _ <- metastore.addPartition(partitionedTable.name, partition, expectedVersionBeforeUpdate)
+        partitionsBeforeUpdate = glue.getPartitions(getPartitionsReq).getPartitions.asScala
+        _ <- metastore.updatePartitionVersion(partitionedTable.name, partition, expectedVersionAfterUpdate)
+        partitionsAfterUpdate = glue.getPartitions(getPartitionsReq).getPartitions.asScala
+
+      } yield (partitionsBeforeUpdate, partitionsAfterUpdate, expectedVersionBeforeUpdate, expectedVersionAfterUpdate)
+
+      val (partitionsBeforeUpdate, partitionsAfterUpdate, expectedVersionBeforeUpdate, expectedVersionAfterUpdate) =
+        scenario.guarantee(deleteTable(partitionedTable.name)).unsafeRunSync()
+
+      partitionsBeforeUpdate should have size 1
+      partitionsBeforeUpdate.head.getStorageDescriptor.getLocation shouldBe s"${tableLocation}date=2019-01-01/${expectedVersionBeforeUpdate.label}"
+      shouldContainFormatParams(partitionsBeforeUpdate.head.getStorageDescriptor)
+
+      partitionsAfterUpdate should have size 1
+      partitionsAfterUpdate.head.getStorageDescriptor.getLocation shouldBe s"${tableLocation}date=2019-01-01/${expectedVersionAfterUpdate.label}"
+      shouldContainFormatParams(partitionsAfterUpdate.head.getStorageDescriptor)
+    }
+
+    "updating a table location" should "preserve format parameters" in {
+      import scala.collection.JavaConverters._
+
+      val scenario = for {
+        _ <- initTable(snapshotTable)
+        metastore = new GlueMetastore[IO](glue)
+        version <- Version.generateVersion
+        _ <- metastore.updateTableLocation(snapshotTable.name, version)
+        getTableReq = new GetTableRequest()
+          .withName(snapshotTable.name.name)
+          .withDatabaseName(snapshotTable.name.schema)
+        glueTable <- IO { glue.getTable(getTableReq) }
+
+      } yield (glueTable.getTable, version)
+
+      val (updatedTable, expectedVersion) =
+        scenario.guarantee(deleteTable(snapshotTable.name)).unsafeRunSync()
+
+      updatedTable.getStorageDescriptor.getLocation shouldBe s"$tableLocation${expectedVersion.label}"
+      shouldContainFormatParams(updatedTable.getStorageDescriptor)
+    }
+
+    def shouldContainFormatParams(storageDescriptor: StorageDescriptor): Assertion = {
+      storageDescriptor.getInputFormat shouldBe testInputFormat
+      storageDescriptor.getOutputFormat shouldBe testOutPutFormat
+      storageDescriptor.getSerdeInfo.getSerializationLibrary shouldBe testSerialisationLib
     }
   }
 

--- a/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
+++ b/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.{Assertion, BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.util.{Properties, Random}
 
-class GlueMetastoreSpec extends FlatSpec with Matchers with BeforeAndAfterAll with MetastoreSpec {
+class GlueMetastoreSpec extends FlatSpec with Matchers with MetastoreSpec {
 
   def readMandatoryEnvVariable(varName: String) =
     Properties.envOrNone(varName).toRight(s"$varName environment variable must be set")

--- a/glue/src/main/scala/com/gu/tableversions/glue/GlueMetastore.scala
+++ b/glue/src/main/scala/com/gu/tableversions/glue/GlueMetastore.scala
@@ -1,6 +1,7 @@
 package com.gu.tableversions.glue
 
 import java.net.URI
+
 import cats.effect.Sync
 import cats.implicits._
 import com.amazonaws.services.glue.AWSGlue
@@ -10,10 +11,11 @@ import com.gu.tableversions.core._
 import com.gu.tableversions.metastore.Metastore.TableOperation
 import com.gu.tableversions.metastore.Metastore.TableOperation._
 import com.gu.tableversions.metastore.{Metastore, VersionPaths}
+import com.typesafe.scalalogging.LazyLogging
 
 import scala.collection.JavaConversions._
 
-class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[F] {
+class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[F] with LazyLogging {
 
   override def currentVersion(table: TableName): F[TableVersion] = {
 
@@ -73,7 +75,8 @@ class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[
       case UpdateTableVersion(versionNumber)          => updateTableLocation(table, versionNumber)
     }
 
-  def addPartition(table: TableName, partition: Partition, version: Version): F[Unit] = {
+  private[glue] def addPartition(table: TableName, partition: Partition, version: Version): F[Unit] = {
+    logger.info(s"adding partition ${partition.columnValues.toList} for table $table and $version")
 
     def partitionLocation(tableLocation: URI): String = {
       val unversionedLocation: String = partition.resolvePath(tableLocation).toString
@@ -85,9 +88,9 @@ class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[
       glueTable <- getGlueTable(table)
       tableLocation = findTableLocation(glueTable)
       location = partitionLocation(tableLocation)
-      storageDescriptor = new StorageDescriptor().withLocation(location)
+      partitionStorageDescriptor = extractFormatParams(glueTable.getStorageDescriptor).withLocation(location)
       partitionValues = partition.columnValues.map(_.value).toList
-      input = new PartitionInput().withValues(partitionValues).withStorageDescriptor(storageDescriptor)
+      input = new PartitionInput().withValues(partitionValues).withStorageDescriptor(partitionStorageDescriptor)
       addPartitionRequest = new CreatePartitionRequest()
         .withDatabaseName(table.schema)
         .withTableName(table.name)
@@ -96,11 +99,11 @@ class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[
     } yield ()
   }
 
-  private def updatePartitionVersion(table: TableName, partition: Partition, version: Version): F[Unit] = {
+  private[glue] def updatePartitionVersion(table: TableName, partition: Partition, version: Version): F[Unit] = {
+    logger.info(s"updating partition ${partition.columnValues.toList} for table $table and $version")
 
-    def updatePartition(partitionLocation: URI): F[Unit] = {
+    def updatePartition(storageDescriptor: StorageDescriptor): F[Unit] = {
       val partitionValues = partition.columnValues.map(_.value).toList
-      val storageDescriptor = new StorageDescriptor().withLocation(partitionLocation.toString)
       val input = new PartitionInput().withValues(partitionValues).withStorageDescriptor(storageDescriptor)
 
       val updatePartitionRequest = new UpdatePartitionRequest()
@@ -112,18 +115,22 @@ class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[
       F.delay(glue.updatePartition(updatePartitionRequest)).void
     }
 
-    versionedPartitionLocation(table, partition, version).flatMap(location => updatePartition(location).void)
+    versionedPartitionStorageDescriptor(table, partition, version).flatMap(location => updatePartition(location).void)
   }
 
-  private def versionedPartitionLocation(table: TableName, partition: Partition, version: Version): F[URI] =
+  private def versionedPartitionStorageDescriptor(
+      table: TableName,
+      partition: Partition,
+      version: Version): F[StorageDescriptor] =
     for {
       gluetable <- getGlueTable(table)
       tableLocation = findTableLocation(gluetable)
       partitionLocation = partition.resolvePath(tableLocation)
       versionedPartitionLocation = VersionPaths.pathFor(partitionLocation, version)
-    } yield versionedPartitionLocation
+    } yield extractFormatParams(gluetable.getStorageDescriptor).withLocation(versionedPartitionLocation.toString)
 
   def removePartition(table: TableName, partition: Partition): F[Unit] = {
+    logger.info(s"removing partition ${partition.columnValues.toList} for table $table")
     val partitionValues = partition.columnValues.map(_.value).toList
     val deletePartitionRequest = new DeletePartitionRequest()
       .withDatabaseName(table.schema)
@@ -133,13 +140,14 @@ class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[
     F.delay(glue.deletePartition(deletePartitionRequest)).void
   }
 
-  def updateTableLocation(table: TableName, version: Version): F[Unit] = {
+  private[glue] def updateTableLocation(table: TableName, version: Version): F[Unit] = {
+    logger.info(s"updating table location for table $table")
     for {
       glueTable <- getGlueTable(table)
       glueTableLocation = new URI(glueTable.getStorageDescriptor.getLocation)
       basePath = VersionPaths.versionedToBasePath(glueTableLocation)
       versionedPath = VersionPaths.pathFor(basePath, version)
-      storageDescriptor = new StorageDescriptor().withLocation(versionedPath.toString)
+      storageDescriptor = extractFormatParams(glueTable.getStorageDescriptor).withLocation(versionedPath.toString)
       tableInput = new TableInput().withName(table.name).withStorageDescriptor(storageDescriptor)
       updateRequest = new UpdateTableRequest().withDatabaseName(table.schema).withTableInput(tableInput)
       res <- F.delay(glue.updateTable(updateRequest))
@@ -159,5 +167,12 @@ class GlueMetastore[F[_]](glue: AWSGlue)(implicit F: Sync[F]) extends Metastore[
   private[glue] def findTableLocation(glueTable: GlueTable) = {
     val location = glueTable.getStorageDescriptor.getLocation
     new URI(location)
+  }
+
+  def extractFormatParams(source: StorageDescriptor): StorageDescriptor = {
+    new StorageDescriptor()
+      .withSerdeInfo(new SerDeInfo().withSerializationLibrary(source.getSerdeInfo.getSerializationLibrary))
+      .withInputFormat(source.getInputFormat)
+      .withOutputFormat(source.getOutputFormat)
   }
 }

--- a/glue/src/test/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
+++ b/glue/src/test/scala/com/gu/tableversions/glue/GlueMetastoreSpec.scala
@@ -1,0 +1,61 @@
+package com.gu.tableversions.glue
+
+import com.amazonaws.services.glue.model.{SerDeInfo, StorageDescriptor}
+import org.scalatest.{FlatSpec, Matchers}
+
+class GlueMetastoreSpec extends FlatSpec with Matchers {
+  val testInputFormat = "org.fake.InputFormat"
+  val testOutPutFormat = "org.fake.OutputFormat"
+  val testSerialisationLib = "org.fake.serde.FakeSerde"
+
+  "extractFormatParams" should "return a storage description with the format params" in {
+    val serdeInfo = new SerDeInfo()
+      .withSerializationLibrary(testSerialisationLib)
+      .withName("shouldBeDropped")
+
+    val descriptorWithExtraParams = new StorageDescriptor()
+      .withSerdeInfo(serdeInfo)
+      .withInputFormat(testInputFormat)
+      .withOutputFormat(testOutPutFormat)
+      .withLocation("shouldBeDropped")
+
+    val actual = GlueMetastore.extractFormatParams(descriptorWithExtraParams)
+
+    actual.getSerdeInfo.getSerializationLibrary shouldBe serdeInfo.getSerializationLibrary
+    actual.getSerdeInfo.getName should be(null)
+    actual.getOutputFormat shouldBe testOutPutFormat
+    actual.getInputFormat shouldBe testInputFormat
+    actual.getLocation should be(null)
+  }
+
+  it should "ignore empty serdeInfo without failing" in {
+    val descriptorWithoutSerdeInfo =
+      new StorageDescriptor().withInputFormat(testInputFormat).withOutputFormat(testOutPutFormat)
+    val actual = GlueMetastore.extractFormatParams(descriptorWithoutSerdeInfo)
+    actual.getInputFormat should be(testInputFormat)
+    actual.getOutputFormat should be(testOutPutFormat)
+    actual.getSerdeInfo should be(null)
+  }
+
+  it should "ignore empty serdeInfo with null library without failing" in {
+    val serdeWithNoLibrary = new SerDeInfo().withName("someName")
+    val descriptorWithNullLibrary = new StorageDescriptor()
+      .withInputFormat(testInputFormat)
+      .withOutputFormat(testOutPutFormat)
+      .withSerdeInfo(serdeWithNoLibrary)
+    val actual = GlueMetastore.extractFormatParams(descriptorWithNullLibrary)
+    actual.getInputFormat should be(testInputFormat)
+    actual.getOutputFormat should be(testOutPutFormat)
+    actual.getSerdeInfo.getSerializationLibrary should be(null)
+  }
+
+  it should "ignore empty input or output format without failing" in {
+    val serdeWithNoLibrary = new SerDeInfo().withSerializationLibrary(testSerialisationLib)
+    val descriptorWithNoFormats = new StorageDescriptor().withSerdeInfo(serdeWithNoLibrary)
+    val actual = GlueMetastore.extractFormatParams(descriptorWithNoFormats)
+    actual.getInputFormat should be(null)
+    actual.getOutputFormat should be(null)
+    actual.getSerdeInfo.getSerializationLibrary shouldBe testSerialisationLib
+  }
+
+}


### PR DESCRIPTION
Fixed a glue with the metastore where the serialization library, input format and output format are left blank when creating partitions. This caused the table not to work properly.

To fix this the metastore will now copy the current table settings every time it performs any operation that involves a glue storageDescriptor (adding partitions or creating a new table or partition version)