### PR TITLE
Metastore refactorings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ lazy val assemblySettings = Seq(
 
 lazy val root = (project in file("."))
   .aggregate(`table-versions-core`,
-             `table-versions-metastore`,
              `table-versions-spark`,
              `table-versions-glue`,
              `table-versions-cli`,
@@ -47,15 +46,10 @@ lazy val `table-versions-core` = project
   .settings(commonSettings)
   .settings(libraryDependencies ++= catsDependencies)
 
-lazy val `table-versions-metastore` = project
-  .in(file("metastore"))
-  .settings(commonSettings)
-  .dependsOn(`table-versions-core`)
-
 lazy val `table-versions-cli` = project
   .in(file("cli"))
   .settings(commonSettings)
-  .dependsOn(`table-versions-core`, `table-versions-metastore`)
+  .dependsOn(`table-versions-core`)
 
 lazy val `table-versions-spark` = project
   .in(file("spark"))
@@ -70,7 +64,7 @@ lazy val `table-versions-spark` = project
   ) ++ sparkDependencies)
   .settings(parallelExecution in Test := false)
   .settings(fork in Test := true)
-  .dependsOn(`table-versions-core`, `table-versions-metastore` % "compile->compile;test->test")
+  .dependsOn(`table-versions-core` % "compile->compile;test->test")
 
 lazy val `table-versions-glue` = project
   .in(file("glue"))
@@ -84,7 +78,7 @@ lazy val `table-versions-glue` = project
     scalatest % IntegrationTest
   ))
   .settings(parallelExecution in Test := false)
-  .dependsOn(`table-versions-core`, `table-versions-metastore` % "compile->compile;test->test;it->test")
+  .dependsOn(`table-versions-core` % "compile->compile;test->test;it->test")
 
 lazy val `table-versions-examples` = project
   .in(file("examples"))
@@ -94,4 +88,4 @@ lazy val `table-versions-examples` = project
   )
   .settings(parallelExecution in Test := false)
   .settings(fork in Test := true)
-  .dependsOn(`table-versions-core`, `table-versions-metastore`, `table-versions-spark` % "compile->compile;test->test")
+  .dependsOn(`table-versions-core`, `table-versions-spark` % "compile->compile;test->test")

--- a/core/src/main/scala/com/gu/tableversions/core/Metastore.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/Metastore.scala
@@ -1,9 +1,7 @@
-package com.gu.tableversions.metastore
+package com.gu.tableversions.core
 
-import com.gu.tableversions.core.Partition.{ColumnValue, PartitionColumn}
-import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore.TableChanges
-import com.gu.tableversions.metastore.Metastore.TableOperation._
+import com.gu.tableversions.core.Metastore.TableChanges
+import com.gu.tableversions.core.Metastore.TableOperation._
 
 /**
   * Defines the API for manipulating and querying a Metastore for versioned tables.

--- a/core/src/main/scala/com/gu/tableversions/core/VersionPaths.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/VersionPaths.scala
@@ -1,10 +1,8 @@
-package com.gu.tableversions.metastore
+package com.gu.tableversions.core
 
 import java.io.File
 import java.net.URI
-import cats.implicits._
-
-import com.gu.tableversions.core.{Partition, Version}
+import cats.syntax.either._
 
 /**
   * Encodes the mapping between version numbers and storage paths.

--- a/core/src/main/scala/com/gu/tableversions/core/VersionPaths.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/VersionPaths.scala
@@ -22,7 +22,6 @@ object VersionPaths {
     }
 
   /**
-    *
     * @return the corresponding version to the provided location
     */
   def parseVersion(location: URI): Version = {
@@ -36,7 +35,6 @@ object VersionPaths {
   }
 
   /**
-    *
     * @return the provided location with the version part removed (if present)
     */
   def versionedToBasePath(location: URI): URI = {

--- a/core/src/main/scala/com/gu/tableversions/core/VersionedMetastore.scala
+++ b/core/src/main/scala/com/gu/tableversions/core/VersionedMetastore.scala
@@ -1,0 +1,68 @@
+package com.gu.tableversions.core
+
+import java.time.Instant
+
+import cats.effect.Sync
+import cats.implicits._
+import com.gu.tableversions.core.Metastore.TableChanges
+import com.gu.tableversions.core.TableVersions._
+
+/**
+  * High level API for table version tracking, that aggregates the functionality from TableVersions and Metastore
+  * in order to provide its functionality.
+  */
+final case class VersionedMetastore[F[_]: Sync](tableVersions: TableVersions[F], metastore: Metastore[F]) {
+
+  /**
+    * Start tracking version information for given table.
+    * This must be called before any other operations can be performed on this table.
+    */
+  def init(table: TableName, isSnapshot: Boolean, userId: UserId, message: UpdateMessage, timestamp: Instant): F[Unit] =
+    tableVersions.init(table, isSnapshot, userId, message, timestamp)
+
+  /**
+    * Get details about partition versions in a table.
+    */
+  def currentVersion(table: TableName): F[TableVersion] =
+    tableVersions.currentVersion(table)
+
+  /**
+    * Get the history of updates for a given table, most recent first.
+    */
+  def updates(table: TableName): F[List[TableUpdateMetadata]] =
+    tableVersions.updates(table)
+
+  /**
+    * Update partition versions to the given versions, and update the metastore to match.
+    *
+    * @return a tuple containing the updated table version information, and a list of the changes that were applied
+    *         to the metastore.
+    */
+  def commit(table: TableName, update: TableUpdate): F[(TableVersion, TableChanges)] =
+    for {
+      // Commit version to version history
+      _ <- tableVersions.commit(table, update)
+
+      // Get latest version details and Metastore table details and find the changes that
+      // need to be applied to the underlying metastore
+      latestTableVersion <- tableVersions.currentVersion(table)
+      metastoreVersion <- metastore.currentVersion(table)
+      metastoreChanges = metastore.computeChanges(metastoreVersion, latestTableVersion)
+
+      // Sync Metastore to match
+      _ <- metastore.update(table, metastoreChanges)
+    } yield (latestTableVersion, metastoreChanges)
+
+  /**
+    * Select an existing version as the current one and update the metastore to match.
+    */
+  def checkout(table: TableName, id: CommitId): F[Unit] =
+    for {
+      _ <- tableVersions.setCurrentVersion(table, id)
+      newVersion <- tableVersions.currentVersion(table)
+      currentMetastoreVersion <- metastore.currentVersion(table)
+      changes = metastore.computeChanges(currentMetastoreVersion, newVersion)
+      _ <- metastore.update(table, changes)
+    } yield ()
+
+}

--- a/core/src/test/scala/com/gu/tableversions/core/MetastoreObjectSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/MetastoreObjectSpec.scala
@@ -1,8 +1,7 @@
-package com.gu.tableversions.metastore
+package com.gu.tableversions.core
 
 import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core.{Partition, PartitionedTableVersion, SnapshotTableVersion, TableVersion, Version}
-import com.gu.tableversions.metastore.Metastore.TableOperation._
+import com.gu.tableversions.core.Metastore.TableOperation._
 import org.scalatest.{FlatSpec, Matchers}
 
 class MetastoreObjectSpec extends FlatSpec with Matchers {

--- a/core/src/test/scala/com/gu/tableversions/core/MetastoreSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/MetastoreSpec.scala
@@ -1,10 +1,9 @@
-package com.gu.tableversions.metastore
+package com.gu.tableversions.core
 
 import cats.effect.IO
+import com.gu.tableversions.core.Metastore.TableChanges
+import com.gu.tableversions.core.Metastore.TableOperation._
 import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore.TableChanges
-import com.gu.tableversions.metastore.Metastore.TableOperation._
 import org.scalatest.{FlatSpec, Matchers}
 
 /**

--- a/core/src/test/scala/com/gu/tableversions/core/VersionPathsSpec.scala
+++ b/core/src/test/scala/com/gu/tableversions/core/VersionPathsSpec.scala
@@ -1,9 +1,7 @@
-package com.gu.tableversions.metastore
+package com.gu.tableversions.core
 
 import java.net.URI
 
-import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core.{Partition, Version}
 import org.scalatest.{FlatSpec, Matchers}
 
 class VersionPathsSpec extends FlatSpec with Matchers {

--- a/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/SnapshotTableLoaderSpec.scala
@@ -34,7 +34,7 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
     import spark.implicits._
 
     val versionContext = TestVersionContext.default.unsafeRunSync()
-    import versionContext.tableVersions
+    import versionContext.metastore
 
     val userId = UserId("test user")
 
@@ -75,15 +75,15 @@ class SnapshotTableLoaderSpec extends FlatSpec with Matchers with SparkHiveSuite
     updatedVersionDirs should contain allElementsOf initialTableVersionDirs
 
     // Get version history
-    val versionHistory = tableVersions.updates(table.name).unsafeRunSync()
+    val versionHistory = metastore.updates(table.name).unsafeRunSync()
     versionHistory.size shouldBe 3 // One initial version plus two written versions
 
     // Roll back to previous version
-    loader.checkout(versionHistory.drop(1).head.id)
+    metastore.checkout(table.name, versionHistory.drop(1).head.id).unsafeRunSync()
     loader.data().collect() should contain theSameElementsAs identitiesDay1
 
     // Roll forward to latest
-    loader.checkout(versionHistory.head.id)
+    metastore.checkout(table.name, versionHistory.head.id).unsafeRunSync()
     loader.data().collect() should contain theSameElementsAs identitiesDay2
   }
 

--- a/examples/src/test/scala/com/gu/tableversions/examples/TestVersionContext.scala
+++ b/examples/src/test/scala/com/gu/tableversions/examples/TestVersionContext.scala
@@ -1,7 +1,7 @@
 package com.gu.tableversions.examples
 
 import cats.effect.IO
-import com.gu.tableversions.core.{InMemoryTableVersions, Version}
+import com.gu.tableversions.core.{InMemoryTableVersions, Version, VersionedMetastore}
 import com.gu.tableversions.spark.{SparkHiveMetastore, VersionContext}
 import org.apache.spark.sql.SparkSession
 
@@ -12,5 +12,5 @@ object TestVersionContext {
       tableVersions <- InMemoryTableVersions[IO]
       metastore = new SparkHiveMetastore[IO]()
       versionGenerator = Version.generateVersion
-    } yield VersionContext(tableVersions, metastore, versionGenerator)
+    } yield VersionContext(VersionedMetastore(tableVersions, metastore), versionGenerator)
 }

--- a/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreIntegrationSpec.scala
+++ b/glue/src/it/scala/com/gu/tableversions/glue/GlueMetastoreIntegrationSpec.scala
@@ -6,27 +6,17 @@ import cats.effect.IO
 import cats.implicits._
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.glue.model.{
-  Column,
-  CreateTableRequest,
-  DeleteTableRequest,
-  GetPartitionsRequest,
-  GetTableRequest,
-  SerDeInfo,
-  StorageDescriptor,
-  TableInput
-}
+import com.amazonaws.services.glue.model._
 import com.amazonaws.services.glue.{AWSGlue, AWSGlueClient}
 import com.gu.tableversions.core.Partition.PartitionColumn
-import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.MetastoreSpec
-import org.scalatest.{Assertion, BeforeAndAfterAll, FlatSpec, Matchers}
+import com.gu.tableversions.core.{MetastoreSpec, _}
+import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import scala.util.{Properties, Random}
 
-class GlueMetastoreSpec extends FlatSpec with Matchers with MetastoreSpec {
+class GlueMetastoreIntegrationSpec extends FlatSpec with Matchers with MetastoreSpec {
 
-  def readMandatoryEnvVariable(varName: String) =
+  def readMandatoryEnvVariable(varName: String): Either[String, String] =
     Properties.envOrNone(varName).toRight(s"$varName environment variable must be set")
 
   val AWSProfileEnvVarName = "TABLE_VERSIONS_TEST_AWS_PROFILE"
@@ -181,7 +171,6 @@ class GlueMetastoreSpec extends FlatSpec with Matchers with MetastoreSpec {
     }
 
     "updating a table location" should "preserve format parameters" in {
-      import scala.collection.JavaConverters._
 
       val scenario = for {
         _ <- initTable(snapshotTable)

--- a/spark/src/main/scala/com/gu/tableversions/spark/SparkHiveMetastore.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/SparkHiveMetastore.scala
@@ -5,9 +5,8 @@ import java.net.URI
 import cats.effect.Sync
 import cats.implicits._
 import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore.TableOperation
-import com.gu.tableversions.metastore.Metastore.TableOperation._
-import com.gu.tableversions.metastore.{Metastore, VersionPaths}
+import com.gu.tableversions.core.Metastore.TableOperation
+import com.gu.tableversions.core.Metastore.TableOperation._
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.SparkSession
 

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionContext.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionContext.scala
@@ -4,11 +4,10 @@ import java.time.Instant
 
 import cats.effect.IO
 import cats.implicits._
-import com.gu.tableversions.core.TableVersions.TableOperation.{AddPartitionVersion, AddTableVersion}
-import com.gu.tableversions.core.TableVersions.{TableOperation, TableUpdate, UpdateMessage, UserId}
+import com.gu.tableversions.core.TableVersions.TableOperation._
+import com.gu.tableversions.core.TableVersions._
 import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore.TableChanges
-import com.gu.tableversions.metastore.{Metastore, VersionPaths}
+import com.gu.tableversions.core.Metastore.TableChanges
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem.VersionedFileSystemConfig
 import org.apache.spark.sql.{Dataset, Row, SaveMode}

--- a/spark/src/main/scala/com/gu/tableversions/spark/VersionContext.scala
+++ b/spark/src/main/scala/com/gu/tableversions/spark/VersionContext.scala
@@ -4,10 +4,10 @@ import java.time.Instant
 
 import cats.effect.IO
 import cats.implicits._
+import com.gu.tableversions.core.Metastore.TableChanges
 import com.gu.tableversions.core.TableVersions.TableOperation._
 import com.gu.tableversions.core.TableVersions._
 import com.gu.tableversions.core._
-import com.gu.tableversions.core.Metastore.TableChanges
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem.VersionedFileSystemConfig
 import org.apache.spark.sql.{Dataset, Row, SaveMode}
@@ -17,8 +17,7 @@ import org.apache.spark.sql.{Dataset, Row, SaveMode}
   * using the appropriate paths for storage, and committing version changes.
   */
 final case class VersionContext(
-    tableVersions: TableVersions[IO],
-    metastore: Metastore[IO],
+    metastore: VersionedMetastore[IO],
     generateVersion: IO[Version]
 )
 
@@ -77,25 +76,15 @@ object SparkSupport {
     }
 
     for {
-      // Get next version to use for all partitions
       newVersion <- generateVersion
 
+      // Write the data
       operations <- if (table.isSnapshot) writeSnapshotDataset(newVersion) else writePartitionedDataset(newVersion)
 
-      // Commit written version
-      _ <- tableVersions.commit(table.name, TableUpdate(userId, UpdateMessage(message), Instant.now(), operations))
+      // Commit version change and update metastore
+      result <- metastore.commit(table.name, TableUpdate(userId, UpdateMessage(message), Instant.now(), operations))
 
-      // Get latest version details and Metastore table details and sync the Metastore to match,
-      // effectively switching the table to the new version.
-      latestTableVersion <- tableVersions.currentVersion(table.name)
-
-      metastoreVersion <- metastore.currentVersion(table.name)
-      metastoreUpdate = metastore.computeChanges(metastoreVersion, latestTableVersion)
-
-      // Sync Metastore to match
-      _ <- metastore.update(table.name, metastoreUpdate)
-
-    } yield (latestTableVersion, metastoreUpdate)
+    } yield result
   }
 
   /**

--- a/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/SparkHiveMetastoreSpec.scala
@@ -4,7 +4,6 @@ import cats.effect.IO
 import cats.syntax.functor._
 import com.gu.tableversions.core.Partition.{ColumnValue, PartitionColumn}
 import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.MetastoreSpec
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
@@ -8,10 +8,8 @@ import cats.effect.IO
 import com.gu.tableversions.core.Partition.PartitionColumn
 import com.gu.tableversions.core.TableVersions._
 import com.gu.tableversions.core._
-import com.gu.tableversions.metastore.Metastore
-import com.gu.tableversions.metastore.Metastore.TableChanges
-import com.gu.tableversions.metastore.Metastore.TableOperation.{AddPartition, UpdateTableVersion}
-import com.gu.tableversions.spark.VersionContext._
+import com.gu.tableversions.core.Metastore.TableChanges
+import com.gu.tableversions.core.Metastore.TableOperation.{AddPartition, UpdateTableVersion}
 import com.gu.tableversions.spark.VersionContextSpec.{Event, User}
 import com.gu.tableversions.spark.filesystem.VersionedFileSystem
 import org.apache.spark.sql.Dataset

--- a/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
+++ b/spark/src/test/scala/com/gu/tableversions/spark/VersionContextSpec.scala
@@ -117,7 +117,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
         _ <- t.init(usersTable.name, isSnapshot = true, UserId("test"), UpdateMessage("init"), Instant.now())
       } yield t).unsafeRunSync()
 
-      VersionContext(tableVersions, stubMetastore, generateVersion)
+      VersionContext(VersionedMetastore(tableVersions, stubMetastore), generateVersion)
     }
 
     import versionContext._
@@ -143,7 +143,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     tableVersion shouldBe SnapshotTableVersion(version1)
     metastoreChanges shouldBe stubbedChanges
 
-    val tableUpdates = tableVersions.updates(usersTable.name).unsafeRunSync()
+    val tableUpdates = metastore.updates(usersTable.name).unsafeRunSync()
     tableUpdates should have size 2
     val tableUpdate = tableUpdates.head
     tableUpdate.message shouldBe UpdateMessage("Test insert users into table")
@@ -172,7 +172,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
         _ <- t.init(eventsTable.name, isSnapshot = false, UserId("test"), UpdateMessage("init"), Instant.now())
       } yield t).unsafeRunSync()
 
-      VersionContext(tableVersions, stubMetastore, generateVersion)
+      VersionContext(VersionedMetastore(tableVersions, stubMetastore), generateVersion)
     }
 
     import versionContext._
@@ -202,7 +202,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     tableVersion shouldBe PartitionedTableVersion(expectedPartitionVersions)
     metastoreChanges shouldBe stubbedChanges
 
-    val tableUpdates = tableVersions.updates(eventsTable.name).unsafeRunSync()
+    val tableUpdates = metastore.updates(eventsTable.name).unsafeRunSync()
     tableUpdates should have size 2
     val tableUpdate = tableUpdates.head
     tableUpdate.message shouldBe UpdateMessage("Test insert events into table")
@@ -230,7 +230,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
         _ <- t.init(eventsTable.name, isSnapshot = false, UserId("test"), UpdateMessage("init"), Instant.now())
       } yield t).unsafeRunSync()
 
-      VersionContext(tableVersions, stubMetastore, generateVersion)
+      VersionContext(VersionedMetastore(tableVersions, stubMetastore), generateVersion)
     }
 
     import versionContext._
@@ -269,7 +269,7 @@ class VersionContextSpec extends FlatSpec with Matchers with SparkHiveSuite {
     tableVersion shouldBe PartitionedTableVersion(expectedPartitionVersions)
     metastoreChanges shouldBe stubbedChanges
 
-    val tableUpdates = tableVersions.updates(eventsTable.name).unsafeRunSync()
+    val tableUpdates = metastore.updates(eventsTable.name).unsafeRunSync()
     tableUpdates should have size 2
     val tableUpdate = tableUpdates.head
     tableUpdate.message shouldBe UpdateMessage("Test insert events into table")


### PR DESCRIPTION
This PR contains a couple of refactorings:

* Removing the `metastore module`, moving the code in it into `core`.

The `Metastore` trait and related code isn't really any less core than `TableVersions` etc so it doesn't make much sense to leave it out of core.

* Creating a new `VersionedMetastore` which combines the `TableVersions` and `Metastore` interface and implements functionality that can be implemented purely in terms of the underlying traits, e.g. setting the metastore to refer to a specific version in history.

This refactoring is enabled by the previous step, and simplifies the application API for versioning, not having to deal with two separate APIs.

As for naming, I think this combination can be viewed as a "version enabled metastore", i.e. a metastore that can remember previous states.

This is a a "draft" until other pending metastore changes have been merged so that these can be merged into this.
